### PR TITLE
Add tests for supabase utilities and middleware

### DIFF
--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,0 +1,29 @@
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/supabase/middleware', () => ({
+  updateSession: jest.fn(),
+}));
+
+const { updateSession } = require('@/lib/supabase/middleware');
+
+describe('root middleware', () => {
+  it('delegates to updateSession', async () => {
+    const res = new Response('ok');
+    (updateSession as jest.Mock).mockResolvedValue(res);
+    const { middleware } = require('../middleware');
+    const req = new NextRequest('http://example.com');
+    const result = await middleware(req);
+    expect(updateSession).toHaveBeenCalledWith(req);
+    expect(result).toBe(res);
+  });
+
+  it('exports matcher config', () => {
+    const { config } = require('../middleware');
+    expect(config).toEqual({
+      matcher: [
+        '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+      ],
+    });
+  });
+});
+

--- a/__tests__/supabase.helpers.test.ts
+++ b/__tests__/supabase.helpers.test.ts
@@ -1,0 +1,95 @@
+import { NextRequest } from 'next/server';
+
+jest.mock('@supabase/ssr', () => ({
+  createBrowserClient: jest.fn(),
+  createServerClient: jest.fn(),
+}));
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}));
+
+let createBrowserClient: jest.Mock;
+let createServerClient: jest.Mock;
+let cookiesFn: jest.Mock;
+
+beforeEach(() => {
+  jest.resetModules();
+  ({ createBrowserClient, createServerClient } = require('@supabase/ssr'));
+  ({ cookies: cookiesFn } = require('next/headers'));
+  createBrowserClient.mockReset();
+  createServerClient.mockReset();
+  cookiesFn.mockReset();
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'url';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'key';
+});
+
+describe('supabase client helper', () => {
+  it('creates browser client with env vars', () => {
+    const mock = {};
+    createBrowserClient.mockReturnValue(mock);
+    const { createClient } = require('../lib/supabase/client');
+    const client = createClient();
+    expect(createBrowserClient).toHaveBeenCalledWith('url', 'key');
+    expect(client).toBe(mock);
+  });
+
+  it('default supabase instance uses createClient', () => {
+    const mock = {};
+    createBrowserClient.mockReturnValue(mock);
+    const mod = require('../lib/supabase/client');
+    expect(mod.supabase).toBe(mock);
+  });
+});
+
+describe('supabase server helper', () => {
+  it('sets up cookie handlers and calls createServerClient', async () => {
+    const store = { get: jest.fn(), set: jest.fn() };
+    cookiesFn.mockReturnValue(store);
+    const client = {};
+    createServerClient.mockReturnValue(client);
+    const { createServerSupabaseClient } = require('../lib/supabase/server');
+    const result = createServerSupabaseClient();
+    expect(result).toBe(client);
+    expect(createServerClient).toHaveBeenCalledWith('url', 'key', expect.any(Object));
+    const opts = createServerClient.mock.calls[0][2];
+    await opts.cookies.get('a');
+    expect(store.get).toHaveBeenCalledWith('a');
+    await opts.cookies.set('b', 'c', { path: '/' });
+    expect(store.set).toHaveBeenCalledWith('b', 'c', { path: '/' });
+    await opts.cookies.remove('d', { path: '/' });
+    expect(store.set).toHaveBeenCalledWith('d', '', { path: '/', maxAge: 0 });
+  });
+});
+
+describe('supabase middleware updateSession', () => {
+  it('redirects unauthenticated users on protected paths', async () => {
+    const supabase = { auth: { getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: null }) } };
+    createServerClient.mockReturnValue(supabase);
+    const { updateSession } = require('../lib/supabase/middleware');
+    const req = new NextRequest('http://example.com/protected');
+    const res = await updateSession(req);
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe('http://example.com/login');
+    expect(supabase.auth.getUser).toHaveBeenCalled();
+  });
+
+  it('returns next response when authenticated', async () => {
+    const supabase = { auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 1 } }, error: null }) } };
+    createServerClient.mockReturnValue(supabase);
+    const { updateSession } = require('../lib/supabase/middleware');
+    const req = new NextRequest('http://example.com/protected');
+    const res = await updateSession(req);
+    expect(res.status).toBe(200);
+  });
+
+  it('allows unauthenticated access to login path', async () => {
+    const supabase = { auth: { getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: null }) } };
+    createServerClient.mockReturnValue(supabase);
+    const { updateSession } = require('../lib/supabase/middleware');
+    const req = new NextRequest('http://example.com/login');
+    const res = await updateSession(req);
+    expect(res.status).toBe(200);
+  });
+});
+


### PR DESCRIPTION
## Summary
- cover supabase client and server helpers
- add tests for updateSession logic
- verify root middleware delegates correctly

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840a33f67d08325b1371cdeecbe980d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added unit tests for middleware functionality, including session handling and route matching.
  - Introduced tests for Supabase client helpers, verifying client creation and session management logic.
  - Ensured authentication behavior is properly tested for both authenticated and unauthenticated users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->