### PR TITLE
Add tests for loaders, SEO and GCP storage

### DIFF
--- a/__tests__/content.loader.test.ts
+++ b/__tests__/content.loader.test.ts
@@ -1,0 +1,77 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+let loader: typeof import('../lib/content/loader');
+const originalCwd = process.cwd();
+
+function makeFile(dir: string, relPath: string, content: string) {
+  const full = path.join(dir, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+describe('content loader', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'content-'));
+    makeFile(
+      tmpDir,
+      'app/content/hub/hub1.md',
+      `---\ntitle: Hub 1\ndescription: Hub desc\ndate: 2024-01-01\n---\n\n# Hub 1 Content`
+    );
+    makeFile(
+      tmpDir,
+      'app/content/spokes/spoke1.md',
+      `---\ntitle: Spoke 1\ndescription: Spoke desc\ndate: 2024-01-02\nhubSlug: hub1\nspokeOrder: 2\n---\n\n# Spoke 1 Content`
+    );
+    process.chdir(tmpDir);
+    jest.resetModules();
+    loader = require('../lib/content/loader');
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('loads hub content', async () => {
+    const hub = await loader.getHubContent('hub1');
+    expect(hub?.meta.title).toBe('Hub 1');
+    expect(hub?.meta.slug).toBe('hub1');
+    expect(hub?.content).toContain('<h1');
+  });
+
+  test('loads spoke content', async () => {
+    const spoke = await loader.getSpokeContent('spoke1');
+    expect(spoke?.meta.hubSlug).toBe('hub1');
+  });
+
+  test('returns all hub content sorted by date', async () => {
+    makeFile(
+      tmpDir,
+      'app/content/hub/hub2.md',
+      `---\ntitle: Hub 2\ndescription: Hub2\ndate: 2024-02-01\n---\n\ntext`
+    );
+    const hubs = await loader.getAllHubContent();
+    expect(hubs.length).toBe(2);
+    expect(hubs[0].meta.slug).toBe('hub2');
+  });
+
+  test('gets spokes for hub ordered by spokeOrder', async () => {
+    makeFile(
+      tmpDir,
+      'app/content/spokes/spoke2.md',
+      `---\ntitle: Spoke 2\ndescription: d\ndate: 2024-01-03\nhubSlug: hub1\nspokeOrder: 1\n---\n\ntext`
+    );
+    const spokes = await loader.getSpokesForHub('hub1');
+    expect(spokes.map(s => s.meta.slug)).toEqual(['spoke2', 'spoke1']);
+  });
+
+  test('collects all slugs', async () => {
+    const slugs = await loader.getAllContentSlugs();
+    expect(slugs.hubSlugs).toContain('hub1');
+    expect(slugs.spokeSlugs).toContain('spoke1');
+  });
+});

--- a/__tests__/seo.test.ts
+++ b/__tests__/seo.test.ts
@@ -1,0 +1,45 @@
+import { generateMetadata, generateViewport, generateJsonLd } from '../lib/seo/seo';
+
+describe('SEO utilities', () => {
+  test('generateMetadata returns defaults', () => {
+    const meta = generateMetadata();
+    expect(meta.title).toMatch(/Testero/);
+    expect(meta.openGraph?.url).toBe('https://testero.ai/');
+  });
+
+  test('generateMetadata uses custom props', () => {
+    const meta = generateMetadata({
+      title: 'Custom',
+      description: 'Desc',
+      keywords: ['a'],
+      ogImage: '/a.jpg',
+      twitterImage: '/b.jpg',
+      noIndex: true,
+      canonical: '/page',
+      useCdn: false,
+    });
+    expect(meta.title).toBe('Custom');
+    expect(meta.description).toBe('Desc');
+    expect(meta.robots).toEqual({ index: false, follow: false });
+    expect(meta.openGraph?.images?.[0].url).toBe('/a.jpg');
+    expect(meta.twitter?.images).toEqual(['/b.jpg']);
+    expect(meta.alternates?.canonical).toBe('https://testero.ai/page');
+  });
+
+  test('generateViewport returns expected config', () => {
+    expect(generateViewport()).toEqual({ width: 'device-width', initialScale: 1, maximumScale: 1 });
+  });
+
+  test('generateJsonLd merges data and handles cdn flag', () => {
+    const json = generateJsonLd({ custom: true });
+    const data = JSON.parse(json);
+    expect(data.custom).toBe(true);
+    const org = data['@graph'][0];
+    expect(org.logo.url).toBe('/logo.png');
+
+    const json2 = generateJsonLd({}, false);
+    const data2 = JSON.parse(json2);
+    const org2 = data2['@graph'][0];
+    expect(org2.logo.url).toBe('https://testero.ai/logo.png');
+  });
+});

--- a/__tests__/slugSafeLoader.test.ts
+++ b/__tests__/slugSafeLoader.test.ts
@@ -1,0 +1,50 @@
+jest.mock('../lib/content/loader', () => ({
+  getHubContent: jest.fn(async (s: string) => `hub:${s}`),
+  getSpokeContent: jest.fn(async (s: string) => `spoke:${s}`),
+  getSpokesForHub: jest.fn(async (s: string) => [`spokes:${s}`]),
+  getAllContentSlugs: jest.fn(),
+  getAllHubContent: jest.fn(),
+  getAllSpokeContent: jest.fn(),
+}));
+
+const loaderMocks = require('../lib/content/loader');
+
+describe('slug safe loader wrappers', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('getHubContentSafe extracts slug from params', async () => {
+    const { getHubContentSafe } = require('../lib/content/slugSafeLoader');
+    const res = await getHubContentSafe({ params: { slug: ['test'] } });
+    expect(loaderMocks.getHubContent).toHaveBeenCalledWith('test');
+    expect(res).toBe('hub:test');
+  });
+
+  test('getHubContentSafe falls back to default', async () => {
+    const { getHubContentSafe } = require('../lib/content/slugSafeLoader');
+    await getHubContentSafe({});
+    expect(loaderMocks.getHubContent).toHaveBeenCalledWith('google-cloud-certification-guide');
+  });
+
+  test('getSpokeContentSafe handles string slug', async () => {
+    const { getSpokeContentSafe } = require('../lib/content/slugSafeLoader');
+    const res = await getSpokeContentSafe('s1');
+    expect(loaderMocks.getSpokeContent).toHaveBeenCalledWith('s1');
+    expect(res).toBe('spoke:s1');
+  });
+
+  test('getSpokesForHubSafe uses provided slug', async () => {
+    const { getSpokesForHubSafe } = require('../lib/content/slugSafeLoader');
+    const res = await getSpokesForHubSafe({ slug: 'hub1' });
+    expect(loaderMocks.getSpokesForHub).toHaveBeenCalledWith('hub1');
+    expect(res).toEqual(['spokes:hub1']);
+  });
+
+  test('re-exports other functions', () => {
+    const mod = require('../lib/content/slugSafeLoader');
+    expect(mod.getAllContentSlugs).toBe(loaderMocks.getAllContentSlugs);
+    expect(mod.getAllHubContent).toBe(loaderMocks.getAllHubContent);
+    expect(mod.getAllSpokeContent).toBe(loaderMocks.getAllSpokeContent);
+  });
+});

--- a/__tests__/storage.functions.test.ts
+++ b/__tests__/storage.functions.test.ts
@@ -1,0 +1,97 @@
+const fileMock = {
+  save: jest.fn(),
+  getSignedUrl: jest.fn(),
+  exists: jest.fn(),
+  delete: jest.fn(),
+};
+const bucketMock = {
+  upload: jest.fn(),
+  file: jest.fn(() => fileMock),
+  setCorsConfiguration: jest.fn(),
+};
+const storageInstance = { bucket: jest.fn(() => bucketMock) };
+const StorageMock = jest.fn(() => storageInstance);
+
+jest.mock('@google-cloud/storage', () => ({
+  Storage: StorageMock,
+}));
+
+describe('gcp storage helpers', () => {
+  const env = process.env;
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...env, GCP_STORAGE_BUCKET_NAME: 'b', GCP_CDN_URL: 'https://cdn' };
+    fileMock.save.mockReset();
+    fileMock.getSignedUrl.mockReset();
+    fileMock.exists.mockReset();
+    fileMock.delete.mockReset();
+    bucketMock.upload.mockReset();
+    bucketMock.setCorsConfiguration.mockReset();
+    storageInstance.bucket.mockClear();
+    StorageMock.mockClear();
+  });
+
+  afterAll(() => {
+    process.env = env;
+  });
+
+  test('initStorage uses key file when provided', () => {
+    process.env.GCP_KEY_FILE_PATH = '/key.json';
+    const { initStorage } = require('../lib/gcp/storage');
+    const client = initStorage();
+    expect(StorageMock).toHaveBeenCalledWith({ keyFilename: '/key.json' });
+    expect(initStorage()).toBe(client); // cached
+  });
+
+  test('uploadFile uploads and returns cdn url', async () => {
+    const { uploadFile } = require('../lib/gcp/storage');
+    const url = await uploadFile('local.txt', 'dest.txt', { contentType: 'text/plain', metadata: { a: 'b' } });
+    expect(bucketMock.upload).toHaveBeenCalledWith('local.txt', expect.objectContaining({ destination: 'dest.txt' }));
+    const opts = bucketMock.upload.mock.calls[0][1];
+    expect(opts.metadata.contentType).toBe('text/plain');
+    expect(opts.metadata.metadata).toEqual({ a: 'b' });
+    expect(url).toBe('https://cdn/dest.txt');
+  });
+
+  test('uploadBuffer saves buffer', async () => {
+    const { uploadBuffer } = require('../lib/gcp/storage');
+    await uploadBuffer(Buffer.from('a'), 'buf.txt', { cacheControl: 'no-cache', contentType: 'text/plain' });
+    expect(fileMock.save).toHaveBeenCalled();
+    const opts = fileMock.save.mock.calls[0][1];
+    expect(opts.metadata.cacheControl).toBe('no-cache');
+    expect(opts.metadata.contentType).toBe('text/plain');
+  });
+
+  test('getSignedUrl returns url', async () => {
+    fileMock.getSignedUrl.mockResolvedValue(['signed']);
+    const { getSignedUrl } = require('../lib/gcp/storage');
+    const url = await getSignedUrl('file.txt', { action: 'write', expires: 10, contentType: 'text/plain' });
+    expect(fileMock.getSignedUrl).toHaveBeenCalled();
+    expect(url).toBe('signed');
+  });
+
+  test('fileExists checks existence', async () => {
+    fileMock.exists.mockResolvedValue([true]);
+    const { fileExists } = require('../lib/gcp/storage');
+    await expect(fileExists('a.txt')).resolves.toBe(true);
+  });
+
+  test('deleteFile removes file', async () => {
+    const { deleteFile } = require('../lib/gcp/storage');
+    await deleteFile('x.txt');
+    expect(fileMock.delete).toHaveBeenCalled();
+  });
+
+  test('configureBucketCors sets configuration', async () => {
+    const { configureBucketCors } = require('../lib/gcp/storage');
+    await configureBucketCors(['https://a.com'], ['GET'], 600);
+    expect(bucketMock.setCorsConfiguration).toHaveBeenCalledWith([
+      {
+        origin: ['https://a.com'],
+        method: ['GET'],
+        responseHeader: ['Content-Type', 'x-goog-meta-*'],
+        maxAgeSeconds: 600,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- cover markdown content loaders
- add slugSafeLoader tests
- provide tests for SEO utilities
- test GCP storage helpers beyond getCdnUrl

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840baae77cc83258548ad216b752394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added comprehensive test suites for content loading, SEO utilities, slug-safe loader functions, and storage helper functions, improving coverage and reliability across these modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->