### PR TITLE
Add signup tests with Jest setup

### DIFF
--- a/__tests__/api.routes.test.ts
+++ b/__tests__/api.routes.test.ts
@@ -1,3 +1,4 @@
+/** @jest-environment node */
 import { NextRequest } from 'next/server';
 
 let serverSupabaseMock: any = { auth: { getUser: jest.fn() }, from: jest.fn() };

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,3 +1,4 @@
+/** @jest-environment node */
 import { NextRequest } from 'next/server';
 
 jest.mock('@/lib/supabase/middleware', () => ({

--- a/__tests__/signup.page.test.tsx
+++ b/__tests__/signup.page.test.tsx
@@ -1,0 +1,55 @@
+/** @jest-environment jsdom */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const captureMock = jest.fn();
+
+jest.mock('posthog-js/react', () => ({
+  usePostHog: () => ({ capture: captureMock }),
+}));
+
+const signUpMock = jest.fn();
+
+jest.mock('../lib/supabase/client', () => ({
+  supabase: { auth: { signUp: signUpMock } },
+}));
+
+import SignupPage from '../app/signup/page';
+
+beforeEach(() => {
+  signUpMock.mockReset();
+  captureMock.mockClear();
+});
+
+test('shows validation errors for empty submission', async () => {
+  render(<SignupPage />);
+  const button = screen.getByRole('button', { name: /sign up/i });
+  await userEvent.click(button);
+  expect(await screen.findByText(/email is required/i)).toBeInTheDocument();
+  expect(await screen.findByText(/password must be at least 8 characters/i)).toBeInTheDocument();
+  expect(signUpMock).not.toHaveBeenCalled();
+});
+
+test('submits valid form and shows confirmation', async () => {
+  signUpMock.mockResolvedValue({ error: null });
+  render(<SignupPage />);
+  await userEvent.type(screen.getByPlaceholderText(/email address/i), 'test@example.com');
+  await userEvent.type(screen.getByPlaceholderText(/password/i), 'password1');
+  await userEvent.click(screen.getByRole('button', { name: /sign up/i }));
+  await waitFor(() => expect(signUpMock).toHaveBeenCalledWith({ email: 'test@example.com', password: 'password1' }));
+  expect(captureMock).toHaveBeenCalledWith('signup_attempt');
+  expect(await screen.findByText(/check your email/i)).toBeInTheDocument();
+});
+
+test('reports sanitized error on signup failure', async () => {
+  signUpMock.mockResolvedValue({ error: { message: 'User already registered' } });
+  render(<SignupPage />);
+  await userEvent.type(screen.getByPlaceholderText(/email address/i), 'test@example.com');
+  await userEvent.type(screen.getByPlaceholderText(/password/i), 'password1');
+  await userEvent.click(screen.getByRole('button', { name: /sign up/i }));
+  await waitFor(() => expect(signUpMock).toHaveBeenCalled());
+  expect(captureMock).toHaveBeenCalledWith('signup_error', { error_code: 'email_exists' });
+  expect(await screen.findByRole('alert')).toHaveTextContent(/user already registered/i);
+});

--- a/__tests__/storage.test.ts
+++ b/__tests__/storage.test.ts
@@ -1,3 +1,4 @@
+/** @jest-environment node */
 let getCdnUrl: typeof import('../lib/gcp/storage').getCdnUrl;
 
 describe('getCdnUrl', () => {

--- a/__tests__/supabase.helpers.test.ts
+++ b/__tests__/supabase.helpers.test.ts
@@ -1,3 +1,4 @@
+/** @jest-environment node */
 import { NextRequest } from 'next/server';
 
 jest.mock('@supabase/ssr', () => ({

--- a/app/signup/page.metadata.tsx
+++ b/app/signup/page.metadata.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Sign Up | Testero',
+  description: 'Create a Testero account to access AI-powered certification exam preparation.',
+  openGraph: {
+    title: 'Sign Up | Testero',
+    description: 'Create a Testero account to access AI-powered certification exam preparation.',
+    url: 'https://testero.ai/signup',
+    siteName: 'Testero',
+    locale: 'en_US',
+    type: 'website',
+  },
+  alternates: {
+    canonical: '/signup',
+  },
+};

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import React, { useState } from 'react';
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import Link from 'next/link';
+import { usePostHog } from "posthog-js/react";
+import { HoverButton } from "@/components/ui/hover-button";
+import { Input } from "@/components/ui/input";
+import { Form, FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";
+import { motion, AnimatePresence } from "framer-motion";
+import { supabase } from '@/lib/supabase/client';
+
+function getSignupErrorCode(message: string): string {
+  const normalized = message.toLowerCase();
+  if (normalized.includes('already registered') || normalized.includes('user already exists')) {
+    return 'email_exists';
+  }
+  if (normalized.includes('invalid email')) {
+    return 'invalid_email';
+  }
+  if (normalized.includes('rate limit')) {
+    return 'rate_limited';
+  }
+  return 'unknown_error';
+}
+
+const signupFormSchema = z.object({
+  email: z
+    .string()
+    .min(1, { message: "Email is required" })
+    .email({ message: "Must be a valid email address" })
+    .transform((val) => val.toLowerCase().trim()),
+  password: z
+    .string()
+    .min(8, { message: "Password must be at least 8 characters" }),
+});
+
+type SignupFormValues = z.infer<typeof signupFormSchema>;
+
+const SignupPage = () => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const posthog = usePostHog();
+
+  const form = useForm<SignupFormValues>({
+    resolver: zodResolver(signupFormSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  });
+
+  async function onSubmit(data: SignupFormValues) {
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      if (posthog) {
+        posthog.capture('signup_attempt');
+      }
+
+      const { error } = await supabase.auth.signUp({
+        email: data.email,
+        password: data.password,
+      });
+
+      if (error) {
+        throw error;
+      }
+
+      setIsSubmitted(true);
+    } catch (err) {
+      const errorMessage =
+        err && typeof err === 'object' && 'message' in err
+          ? String((err as { message: string }).message)
+          : 'Something went wrong. Please try again.';
+      setError(errorMessage);
+      if (posthog) {
+        posthog.capture('signup_error', {
+          error_code: getSignupErrorCode(errorMessage),
+        });
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen pt-24 pb-12 md:pt-32 flex flex-col items-center justify-start bg-gradient-to-b from-slate-50 to-slate-100">
+      <div className="w-full max-w-md px-6">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+          className="bg-white shadow-lg rounded-xl border border-slate-200 overflow-hidden"
+        >
+          <div className="px-6 py-8 text-center border-b border-slate-200 bg-gradient-to-r from-slate-50 to-slate-100">
+            <h1 className="text-2xl md:text-3xl font-bold text-slate-800 mb-2">Create your account</h1>
+            <p className="text-slate-600">Sign up to start practicing with Testero</p>
+          </div>
+
+          <div className="px-6 py-8">
+            <AnimatePresence mode="wait">
+              {!isSubmitted ? (
+                <motion.div key="form" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+                  <Form {...form}>
+                    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+                      <FormField
+                        control={form.control}
+                        name="email"
+                        render={({ field, fieldState }) => (
+                          <FormItem>
+                            <div className="relative">
+                              <FormControl>
+                                <Input
+                                  type="email"
+                                  placeholder="Email address"
+                                  className={`px-4 py-3 text-base rounded-md transition-all duration-300 border-2 ${
+                                    fieldState.error
+                                      ? 'border-red-400 bg-red-50'
+                                      : fieldState.isDirty && !fieldState.error
+                                        ? 'border-green-400 bg-green-50'
+                                        : 'border-slate-300 focus:border-orange-400 focus:ring focus:ring-orange-200 focus:ring-opacity-50'
+                                  }`}
+                                  disabled={isSubmitting}
+                                  autoComplete="email"
+                                  autoFocus
+                                  aria-required="true"
+                                  aria-invalid={fieldState.error ? 'true' : 'false'}
+                                  {...field}
+                                />
+                              </FormControl>
+                              {fieldState.isDirty && (
+                                <div className="absolute right-3 top-1/2 transform -translate-y-1/2">
+                                  {fieldState.error ? (
+                                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-red-500" viewBox="0 0 20 20" fill="currentColor">
+                                      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+                                    </svg>
+                                  ) : (
+                                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-green-500" viewBox="0 0 20 20" fill="currentColor">
+                                      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                                    </svg>
+                                  )}
+                                </div>
+                              )}
+                            </div>
+                            <FormMessage className="text-left mt-1 font-medium" />
+                          </FormItem>
+                        )}
+                      />
+
+                      <FormField
+                        control={form.control}
+                        name="password"
+                        render={({ field, fieldState }) => (
+                          <FormItem>
+                            <div className="relative">
+                              <FormControl>
+                                <Input
+                                  type="password"
+                                  placeholder="Password"
+                                  className={`px-4 py-3 text-base rounded-md transition-all duration-300 border-2 ${
+                                    fieldState.error
+                                      ? 'border-red-400 bg-red-50'
+                                      : fieldState.isDirty && !fieldState.error
+                                        ? 'border-green-400 bg-green-50'
+                                        : 'border-slate-300 focus:border-orange-400 focus:ring focus:ring-orange-200 focus:ring-opacity-50'
+                                  }`}
+                                  disabled={isSubmitting}
+                                  autoComplete="new-password"
+                                  aria-required="true"
+                                  aria-invalid={fieldState.error ? 'true' : 'false'}
+                                  {...field}
+                                />
+                              </FormControl>
+                              {fieldState.isDirty && (
+                                <div className="absolute right-3 top-1/2 transform -translate-y-1/2">
+                                  {fieldState.error ? (
+                                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-red-500" viewBox="0 0 20 20" fill="currentColor">
+                                      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+                                    </svg>
+                                  ) : (
+                                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-green-500" viewBox="0 0 20 20" fill="currentColor">
+                                      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                                    </svg>
+                                  )}
+                                </div>
+                              )}
+                            </div>
+                            <FormMessage className="text-left mt-1 font-medium" />
+                          </FormItem>
+                        )}
+                      />
+
+                      {error && (
+                        <motion.div
+                          initial={{ opacity: 0, y: -10 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          className="bg-red-50 border border-red-200 rounded-md px-4 py-3 text-center"
+                          role="alert"
+                          aria-live="assertive"
+                        >
+                          <p className="text-red-600 font-medium flex items-center justify-center text-sm">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 mr-2" aria-hidden="true">
+                              <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+                            </svg>
+                            {error}
+                          </p>
+                        </motion.div>
+                      )}
+
+                      <HoverButton
+                        className="bg-gradient-to-r from-orange-500 to-orange-600 hover:from-orange-600 hover:to-orange-700 text-white px-6 py-3 rounded-md text-base font-semibold shadow-md w-full transition-all"
+                        type="submit"
+                        disabled={isSubmitting}
+                        aria-busy={isSubmitting ? 'true' : 'false'}
+                      >
+                        {isSubmitting ? (
+                          <div className="flex items-center justify-center">
+                            <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                            </svg>
+                            Signing up...
+                          </div>
+                        ) : (
+                          <div className="flex items-center justify-center">
+                            <span>Sign Up</span>
+                          </div>
+                        )}
+                      </HoverButton>
+                    </form>
+                  </Form>
+                </motion.div>
+              ) : (
+                <motion.div key="success" initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-6 text-center">
+                  <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-green-100">
+                    <svg className="h-6 w-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                  </div>
+                  <h3 className="text-lg font-medium text-slate-900">Check your email</h3>
+                  <p className="text-slate-600">We've sent a confirmation link to {form.getValues().email}. Please follow the instructions to complete your registration.</p>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        </motion.div>
+
+        <div className="mt-8 text-center">
+          <p className="text-slate-600">
+            Already have an account?{' '}
+            <Link href="/login" className="text-orange-500 hover:text-orange-600 transition-colors font-medium">
+              Sign in
+            </Link>
+          </p>
+        </div>
+
+        <div className="absolute inset-0 opacity-10 pointer-events-none" aria-hidden="true">
+          <div className="absolute top-0 left-1/4 w-64 h-64 rounded-full bg-blue-500 mix-blend-multiply blur-3xl"></div>
+          <div className="absolute bottom-0 right-1/4 w-64 h-64 rounded-full bg-orange-500 mix-blend-multiply blur-3xl"></div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SignupPage;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,17 +2,18 @@ import type { Config } from 'jest';
 
 export default {
   preset: 'ts-jest',
-  testEnvironment: 'node',
-  testMatch: ['**/__tests__/**/*.test.ts'],
+  testEnvironment: 'jsdom',
+  testMatch: ['**/__tests__/**/*.test.ts?(x)'],
   transform: {
     '^.+\\.(t|j)sx?$': [
       'ts-jest',
       {
-        tsconfig: 'tsconfig.json',
+        tsconfig: 'tsconfig.jest.json',
       },
     ],
   },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 } satisfies Config;

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -75,6 +75,10 @@
     "tailwindcss": "^4",
     "ts-jest": "^29.3.4",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "@testing-library/react": "^15.0.7",
+    "@testing-library/user-event": "^14.6.1",
+    "@testing-library/jest-dom": "^6.2.0",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
## Summary
- add React Testing Library packages
- update Jest config with setup and tsx matching
- include jest-dom setup
- add tests for signup page
- sanitize analytics event data
- ensure jsdom environment for all tests using ts-jest setup
- sanitize PostHog error capture with generic codes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68475ae955448325afb1ea67a386088a