### PR TITLE
TES-265: Consolidate client sign-up to use /api/auth/signup endpoint

### DIFF
--- a/__tests__/api.signup.test.ts
+++ b/__tests__/api.signup.test.ts
@@ -21,7 +21,14 @@ describe('signupBusinessLogic', () => {
     const res = await signupBusinessLogic({ email: 'test@example.com', password: 'password123', ip: '1.1.1.1', supabaseClient, analytics });
     expect(res.status).toBe(200);
     expect((res.body as SignupSuccessResponse).status).toBe('ok');
-    expect(analytics.capture).toHaveBeenCalledWith({ event: 'signup_success', properties: { email: 'test@example.com' } });
+    expect(analytics.capture).toHaveBeenCalledWith({ 
+      event: 'signup_success', 
+      properties: { 
+        email: 'test@example.com',
+        guestUpgraded: false,
+        sessionsTransferred: 0
+      } 
+    });
   });
 
   it('returns 400 for invalid email', async () => {

--- a/__tests__/signup.page.test.tsx
+++ b/__tests__/signup.page.test.tsx
@@ -10,16 +10,18 @@ jest.mock('posthog-js/react', () => ({
   usePostHog: () => ({ capture: captureMock }),
 }));
 
-const signUpMock = jest.fn();
-
-jest.mock('../lib/supabase/client', () => ({
-  supabase: { auth: { signUp: signUpMock } },
+// Mock the anonymous session utility
+jest.mock('../lib/auth/anonymous-session', () => ({
+  getAnonymousSessionId: jest.fn(() => 'mock-anonymous-session-id'),
 }));
+
+// Mock fetch globally
+global.fetch = jest.fn();
 
 import SignupPage from '../app/signup/page';
 
 beforeEach(() => {
-  signUpMock.mockReset();
+  (global.fetch as jest.Mock).mockReset();
   captureMock.mockClear();
 });
 
@@ -29,16 +31,56 @@ test('shows validation errors for empty submission', async () => {
   await userEvent.click(button);
   expect(await screen.findByText(/email is required/i)).toBeInTheDocument();
   expect(await screen.findByText(/password must be at least 8 characters/i)).toBeInTheDocument();
-  expect(signUpMock).not.toHaveBeenCalled();
+  expect(global.fetch).not.toHaveBeenCalled();
 });
 
 test('submits valid form and shows confirmation', async () => {
-  signUpMock.mockResolvedValue({ error: null });
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    json: async () => ({ status: 'ok', guestUpgraded: false, sessionsTransferred: 0 }),
+  });
+
   render(<SignupPage />);
   await userEvent.type(screen.getByPlaceholderText(/email address/i), 'test@example.com');
-  await userEvent.type(screen.getByPlaceholderText(/password/i), 'password1');
+  await userEvent.type(screen.getByPlaceholderText(/password/i), 'password123');
   await userEvent.click(screen.getByRole('button', { name: /sign up/i }));
-  await waitFor(() => expect(signUpMock).toHaveBeenCalledWith({ email: 'test@example.com', password: 'password1' }));
+
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenCalledWith('/api/auth/signup', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email: 'test@example.com',
+        password: 'password123',
+        anonymousSessionId: 'mock-anonymous-session-id',
+      }),
+    });
+  });
+
   expect(captureMock).toHaveBeenCalledWith('signup_attempt');
+  expect(captureMock).toHaveBeenCalledWith('signup_success', {
+    guestUpgraded: false,
+    sessionsTransferred: 0,
+  });
   expect(await screen.findByText(/check your email/i)).toBeInTheDocument();
+});
+
+test('handles API errors correctly', async () => {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: false,
+    json: async () => ({ error: 'Email already registered' }),
+  });
+
+  render(<SignupPage />);
+  await userEvent.type(screen.getByPlaceholderText(/email address/i), 'existing@example.com');
+  await userEvent.type(screen.getByPlaceholderText(/password/i), 'password123');
+  await userEvent.click(screen.getByRole('button', { name: /sign up/i }));
+
+  expect(await screen.findByText(/email already registered/i)).toBeInTheDocument();
+  expect(captureMock).toHaveBeenCalledWith('signup_attempt');
+  expect(captureMock).toHaveBeenCalledWith('signup_error', {
+    error_message: 'Email already registered',
+  });
 });


### PR DESCRIPTION
## Summary
- Replace direct Supabase client calls with centralized `/api/auth/signup` endpoint  
- Enable automatic guest session upgrade functionality during signup
- Improve error handling and analytics tracking consistency
- Reduce client-side dependencies and improve maintainability

## Changes Made
- **Signup Page**: Replace `supabase.auth.signUp()` with `fetch('/api/auth/signup')`
- **Anonymous Session Integration**: Include anonymous session ID for guest upgrade
- **Enhanced Analytics**: Track guest upgrade information (sessions transferred, etc.)
- **Updated Tests**: Mock fetch API instead of Supabase client, add error handling tests
- **Test Fixes**: Update signup business logic test expectations for new analytics structure

## Benefits
- ✅ **Centralized Logic**: All signup flows now use the same business logic with rate limiting
- ✅ **Guest Upgrade**: Automatic transfer of anonymous diagnostic sessions to new users  
- ✅ **Consistent Error Handling**: Unified error messages and analytics tracking
- ✅ **Reduced Dependencies**: Remove direct Supabase client usage from signup form
- ✅ **Better Testing**: More realistic API testing with fetch mocks

## Test Plan
- [x] All signup page tests pass (3/3)
- [x] Signup business logic tests pass (5/5) 
- [x] Form validation still works correctly
- [x] Error handling displays proper messages
- [x] Guest session upgrade functionality preserved
- [x] ESLint and TypeScript compilation pass

🤖 Generated with [Claude Code](https://claude.ai/code)