### PR TITLE
TES-268: Enable rate limiting on signup endpoint

### DIFF
--- a/__tests__/guest-session-upgrade.test.ts
+++ b/__tests__/guest-session-upgrade.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { signupBusinessLogic, rateLimitMap } from '@/lib/auth/signup-handler';
+import { signupBusinessLogic } from '@/lib/auth/signup-handler';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 // Mock crypto.randomUUID for consistent testing
@@ -21,8 +21,7 @@ describe('Guest Session Upgrade', () => {
     // Reset all mocks
     jest.clearAllMocks();
     
-    // Clear rate limit map between tests
-    rateLimitMap.clear();
+    // Rate limiting is now handled at API route level
 
     // Mock analytics
     mockAnalytics = {
@@ -111,7 +110,6 @@ describe('Guest Session Upgrade', () => {
       const result = await signupBusinessLogic({
         email: 'test@example.com',
         password: 'password123',
-        ip: '127.0.0.1',
         supabaseClient: mockSupabaseClient,
         analytics: mockAnalytics,
         anonymousSessionId,
@@ -177,7 +175,6 @@ describe('Guest Session Upgrade', () => {
       const result = await signupBusinessLogic({
         email: 'test@example.com',
         password: 'password123',
-        ip: '127.0.0.1',
         supabaseClient: mockSupabaseClient,
         analytics: mockAnalytics,
         // No anonymousSessionId provided
@@ -234,7 +231,6 @@ describe('Guest Session Upgrade', () => {
       const result = await signupBusinessLogic({
         email: 'test@example.com',
         password: 'password123',
-        ip: '127.0.0.1',
         supabaseClient: mockSupabaseClient,
         analytics: mockAnalytics,
         anonymousSessionId,
@@ -280,7 +276,6 @@ describe('Guest Session Upgrade', () => {
       const result = await signupBusinessLogic({
         email: 'test@example.com',
         password: 'password123',
-        ip: '127.0.0.1',
         supabaseClient: mockSupabaseClient,
         analytics: mockAnalytics,
         anonymousSessionId,
@@ -322,7 +317,6 @@ describe('Guest Session Upgrade', () => {
       const result = await signupBusinessLogic({
         email: 'test@example.com',
         password: 'password123',
-        ip: '127.0.0.1',
         supabaseClient: mockSupabaseClient,
         analytics: mockAnalytics,
         anonymousSessionId: 'anon-session-999',
@@ -346,40 +340,12 @@ describe('Guest Session Upgrade', () => {
       expect(mockSupabaseClient.from).not.toHaveBeenCalled();
     });
 
-    test('should handle rate limiting', async () => {
-      // Mock rate limit check by calling signup multiple times quickly
-      const signupParams = {
-        email: 'test@example.com',
-        password: 'password123',
-        ip: '127.0.0.1',
-        supabaseClient: mockSupabaseClient,
-        analytics: mockAnalytics,
-      };
-
-      // First 5 requests should succeed (within rate limit)
-      for (let i = 0; i < 5; i++) {
-        const result = await signupBusinessLogic(signupParams);
-        expect(result.status).toBe(200);
-      }
-
-      // 6th request should be rate limited
-      const rateLimitedResult = await signupBusinessLogic(signupParams);
-      expect(rateLimitedResult.status).toBe(429);
-      expect(rateLimitedResult.body).toEqual({
-        error: 'Too many sign-up attempts',
-      });
-
-      expect(mockAnalytics.capture).toHaveBeenCalledWith({
-        event: 'signup_rate_limited',
-        properties: { ip: '127.0.0.1' },
-      });
-    });
+    // Rate limiting test removed - now handled at API route level
 
     test('should handle invalid input validation', async () => {
       const result = await signupBusinessLogic({
         email: 'invalid-email',
         password: '123', // Too short
-        ip: '127.0.0.1',
         supabaseClient: mockSupabaseClient,
         analytics: mockAnalytics,
       });

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -47,6 +47,7 @@ export async function updateSession(request: NextRequest) {
     !request.nextUrl.pathname.startsWith('/faq') &&
     !request.nextUrl.pathname.startsWith('/diagnostic') &&
     !request.nextUrl.pathname.startsWith('/api/diagnostic') &&
+    !request.nextUrl.pathname.startsWith('/api/auth') &&
     !request.nextUrl.pathname.startsWith('/_next') &&
     !request.nextUrl.pathname.startsWith('/favicon.ico') &&
     request.nextUrl.pathname !== '/'


### PR DESCRIPTION
## Summary
- Enable rate limiting in signup API route (3 requests/minute standardized with other auth endpoints)
- Remove duplicate rate limiting from business logic handler to avoid double limiting
- Fix critical middleware bug blocking all auth API endpoints

## Technical Changes
- Add rate limiting check to `/app/api/auth/signup/route.ts` before business logic
- Remove rate limiting from `/lib/auth/signup-handler.ts` to maintain single responsibility
- Fix middleware to allow `/api/auth/*` endpoints (critical bug fix)
- Update tests to reflect new architecture where rate limiting is handled at API route level

## Security Impact
- ✅ Signup endpoint now protected against spam/abuse (3 requests/minute)
- ✅ Consistent rate limiting across all auth endpoints
- ✅ Auth API endpoints accessible (middleware bug fixed)

## Test Plan
- [x] Manual testing confirms rate limiting works (3 requests allowed, 4th gets 429)
- [x] Rate limit resets after 1 minute window
- [x] All existing unit tests pass
- [x] TypeScript compilation and linting pass
- [x] Auth endpoints accessible via middleware

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced in-memory rate limiting for the signup endpoint, limiting requests to 3 per minute per IP address.

- **Bug Fixes**
  - Ensured consistent rate limiting across authentication endpoints by moving rate limiting to the API route level.

- **Tests**
  - Updated test suites to reflect the new rate limiting implementation and removed obsolete rate limiting test cases.

- **Refactor**
  - Simplified signup business logic by removing internal rate limiting and related parameters.

- **Chores**
  - Adjusted middleware to avoid redirecting unauthenticated users on authentication API routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->