### PR TITLE
TES-277: Add missing environment variables to production deployment

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,7 +23,7 @@ steps:
       - '--min-instances=0'
       - '--max-instances=10'
       - '--port=3000'
-      - '--set-env-vars=NODE_ENV=production'
+      - '--set-env-vars=NODE_ENV=production,NEXT_PUBLIC_SITE_URL=https://testero.ai'
 
 # Store images in Google Artifact Registry
 images:


### PR DESCRIPTION
## Summary
• Added `NEXT_PUBLIC_SITE_URL=https://testero.ai` to production Cloud Run deployment configuration
• Fixes critical authentication redirect issue where production auth flows defaulted to localhost
• Ensures email verification and password reset links work correctly in production

## Problem Solved
• **CRITICAL**: Production auth redirects were falling back to `http://localhost:3000`
• Email verification links in production pointed to localhost instead of production domain
• Password reset links in production pointed to localhost instead of production domain  
• Users unable to complete authentication flows in production environment

## Technical Implementation
• Updated `cloudbuild.yaml` to include `NEXT_PUBLIC_SITE_URL` in `--set-env-vars`
• Authentication flows now properly use `https://testero.ai` for redirects in production
• Affects all auth endpoints: signup, password reset, and resend confirmation

## Authentication Flows Fixed
• **Email Verification**: `/verify-email` redirects now work in production
• **Password Reset**: `/reset-password` redirects now work in production  
• **Resend Confirmation**: Email verification resend now uses correct production URLs

## Deployment Requirements
⚠️ **IMPORTANT**: After deployment, verify Supabase dashboard is configured with these redirect URLs:
- `https://testero.ai/verify-email`
- `https://testero.ai/reset-password`

Navigate to: Supabase Dashboard → Authentication → URL Configuration → Redirect URLs

## Test plan
- [x] TypeScript compilation passes without errors
- [x] ESLint validation succeeds with no warnings  
- [x] Production build completes successfully
- [x] Environment variable correctly set in cloudbuild.yaml
- [x] Auth redirect code properly uses NEXT_PUBLIC_SITE_URL
- [ ] **Post-deployment**: Test email verification flow in production
- [ ] **Post-deployment**: Test password reset flow in production
- [ ] **Post-deployment**: Verify Supabase redirect URLs are configured

🤖 Generated with [Claude Code](https://claude.ai/code)