### PR TITLE
Fix infinite redirect loop on blog routes

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -62,12 +62,6 @@ const nextConfig = {
         destination: '/blog/google-cloud-digital-leader-certification',
         permanent: true,
       },
-      // Keep existing blog routes for backward compatibility
-      {
-        source: '/blog/:slug*',
-        destination: '/blog/:slug*',
-        permanent: false,
-      },
     ];
 
     const productionOnlyRedirects = process.env.NODE_ENV === 'production'


### PR DESCRIPTION
## Summary
- Removed self-referencing redirect configuration that was causing ERR_TOO_MANY_REDIRECTS
- Blog routes now work correctly without infinite redirect loops

## Problem
The `/blog/*` routes were configured with a redirect that pointed to themselves:
```javascript
{
  source: '/blog/:slug*',
  destination: '/blog/:slug*',
  permanent: false,
}
```

This caused browsers to hit the redirect limit and show ERR_TOO_MANY_REDIRECTS.

## Solution
Removed the problematic redirect from `next.config.mjs`. The blog routes already exist and work properly without this redirect.

## Test plan
- [x] Build passes locally
- [ ] Deploy to staging/preview
- [ ] Navigate to `/blog` - should load without redirect errors
- [ ] Navigate to any blog post - should load without redirect errors

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a redundant temporary redirect on blog routes that pointed to the same URL, eliminating unnecessary round trips and page flicker.
* **Performance**
  * Faster initial load for blog pages by bypassing the no-op redirect.
* **Chores**
  * Simplified routing configuration by removing an obsolete redirect rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->