### PR TITLE
🚨 CRITICAL: Fix email delivery by adding missing runtime environment variables

### DIFF
--- a/.github/workflows/deploy-to-cloud-run.yml
+++ b/.github/workflows/deploy-to-cloud-run.yml
@@ -148,7 +148,7 @@ jobs:
             --min-instances=0
             --max-instances=10
             --port=3000
-            --set-env-vars=NODE_ENV=production
+            --set-env-vars=NODE_ENV=production,NEXT_PUBLIC_SITE_URL=${{ secrets.NEXT_PUBLIC_SITE_URL }},NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }},NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }},NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }},NEXT_PUBLIC_POSTHOG_HOST=${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
       
       - name: Show Output
         run: echo "Deployed to ${{ steps.deploy.outputs.url }}"


### PR DESCRIPTION
## Critical Bug Fix: Email Delivery Not Working

### Root Cause Identified
- Supabase environment variables were passed as Docker **build arguments** but not **runtime environment variables**
- This caused signup to return 200 but silently fail to create users or send emails
- Cloud Run service only had `NODE_ENV=production` set at runtime

### Changes Made
- ✅ Added `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` as runtime env vars
- ✅ Added `NEXT_PUBLIC_SITE_URL` for proper email redirect URLs  
- ✅ Added PostHog analytics environment variables
- ✅ Verified all secrets exist in GitHub repository

### Testing Plan
- [x] Confirmed GitHub secrets are properly configured
- [x] Updated workflow to pass secrets as runtime environment variables
- [ ] Deploy and test signup flow with real email
- [ ] Verify users are created in Supabase Auth table
- [ ] Confirm emails are delivered via Loops

### Impact
This fixes the signup email delivery issue where:
1. Users could submit signup forms successfully (200 response)
2. But no user accounts were created in Supabase
3. No confirmation emails were sent via Loops

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated deployment configuration to include required public environment variables from secure secrets during Cloud Run deploys. This ensures the correct site URL, backend connectivity, and analytics tracking function as expected in production.
  * Improves reliability of production environments and prevents missing-configuration issues after releases. No changes to local behavior or other workflow steps; no downtime expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->