### PR TITLE
Add shared Next.js App Router mocks for Jest

### DIFF
--- a/__tests__/test-utils/mockNextNavigation.ts
+++ b/__tests__/test-utils/mockNextNavigation.ts
@@ -1,0 +1,100 @@
+import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
+
+type MockRouterFn = jest.Mock<ReturnType<AppRouterInstance['push']>, Parameters<AppRouterInstance['push']>>;
+
+type RouterMethod = jest.Mock<ReturnType<AppRouterInstance['back']>, Parameters<AppRouterInstance['back']>>;
+
+type PrefetchMethod = jest.Mock<ReturnType<AppRouterInstance['prefetch']>, Parameters<AppRouterInstance['prefetch']>>;
+
+export interface MockAppRouterInstance extends Omit<AppRouterInstance, 'push' | 'replace' | 'prefetch' | 'back' | 'forward' | 'refresh'> {
+  push: MockRouterFn;
+  replace: MockRouterFn;
+  back: RouterMethod;
+  forward: RouterMethod;
+  refresh: RouterMethod;
+  prefetch: PrefetchMethod;
+}
+
+const createRouterState = (overrides: Partial<MockAppRouterInstance> = {}): MockAppRouterInstance => ({
+  back: jest.fn(),
+  forward: jest.fn(),
+  prefetch: jest.fn().mockResolvedValue(undefined),
+  push: jest.fn(),
+  replace: jest.fn(),
+  refresh: jest.fn(),
+  pathname: '/',
+  query: {},
+  params: {},
+  ...overrides,
+});
+
+export const mockRouter: MockAppRouterInstance = createRouterState();
+
+export const resetMockRouter = (overrides: Partial<MockAppRouterInstance> = {}): void => {
+  Object.assign(mockRouter, createRouterState(overrides));
+};
+
+type IteratorFactory<T> = () => IterableIterator<T>;
+
+type ForEachCallback = (value: string, key: string, parent: ReadonlyURLSearchParams) => void;
+
+export interface MockReadonlyURLSearchParams {
+  get: jest.Mock<string | null, [string]>;
+  getAll: jest.Mock<string[], [string]>;
+  has: jest.Mock<boolean, [string]>;
+  entries: jest.Mock<IterableIterator<[string, string]>, []>;
+  keys: jest.Mock<IterableIterator<string>, []>;
+  values: jest.Mock<IterableIterator<string>, []>;
+  forEach: jest.Mock<void, [ForEachCallback]>;
+  toString: jest.Mock<string, []>;
+  setParams: (params?: Record<string, string>) => void;
+  resetMocks: () => void;
+}
+
+const cloneIterator = <T>(factory: IteratorFactory<T>): IterableIterator<T> => {
+  const snapshot = Array.from(factory());
+  return snapshot[Symbol.iterator]();
+};
+
+const createSearchParamsState = (initial: Record<string, string> = {}): MockReadonlyURLSearchParams => {
+  let current = new URLSearchParams(initial);
+
+  const api: MockReadonlyURLSearchParams = {
+    get: jest.fn((key: string) => current.get(key)),
+    getAll: jest.fn((key: string) => current.getAll(key)),
+    has: jest.fn((key: string) => current.has(key)),
+    entries: jest.fn(() => cloneIterator(() => current.entries())),
+    keys: jest.fn(() => cloneIterator(() => current.keys())),
+    values: jest.fn(() => cloneIterator(() => current.values())),
+    forEach: jest.fn((callback: ForEachCallback) => {
+      current.forEach((value, key) => callback(value, key, api as unknown as ReadonlyURLSearchParams));
+    }),
+    toString: jest.fn(() => current.toString()),
+    setParams: (params: Record<string, string> = {}) => {
+      current = new URLSearchParams(params);
+    },
+    resetMocks: () => {
+      api.get.mockClear();
+      api.getAll.mockClear();
+      api.has.mockClear();
+      api.entries.mockClear();
+      api.keys.mockClear();
+      api.values.mockClear();
+      api.forEach.mockClear();
+      api.toString.mockClear();
+    },
+  };
+
+  return api;
+};
+
+export const mockSearchParams: MockReadonlyURLSearchParams = createSearchParamsState();
+
+export const resetMockSearchParams = (params?: Record<string, string>): void => {
+  mockSearchParams.setParams(params ?? {});
+  mockSearchParams.resetMocks();
+};
+
+export const setMockSearchParams = (params: Record<string, string>): void => {
+  mockSearchParams.setParams(params);
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,6 +1,23 @@
 import "@testing-library/jest-dom";
 // All undici and Web API polyfills removed for pure business logic test compatibility.
 
+import {
+  mockRouter,
+  mockSearchParams,
+  resetMockRouter,
+  resetMockSearchParams,
+} from "./__tests__/test-utils/mockNextNavigation";
+
+// Ensure App Router hooks from next/navigation resolve to stable mocks.
+jest.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+  usePathname: () => mockRouter.pathname,
+  useSearchParams: () => mockSearchParams,
+  useParams: () => mockRouter.params ?? {},
+  redirect: jest.fn(),
+  notFound: jest.fn(),
+}));
+
 // Set up test environment variables
 process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
 process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "test-anon-key";
@@ -37,6 +54,11 @@ jest.mock("next/headers", () => ({
     forEach: jest.fn(),
   })),
 }));
+
+beforeEach(() => {
+  resetMockRouter();
+  resetMockSearchParams();
+});
 
 // Mock IntersectionObserver for Framer Motion animations
 global.IntersectionObserver = jest.fn().mockImplementation(() => ({


### PR DESCRIPTION
## Summary
- add a reusable `mockNextNavigation` helper that stubs Next.js App Router hooks for tests
- wire the shared mock into `jest.setup.ts` and reset between tests to avoid cross-suite leakage

## Testing
- npm test -- __tests__/beta-page.test.tsx
- npm test -- __tests__/beta-page-content.test.tsx
- npm test -- __tests__/forgot-password.page.test.tsx
- npm test -- __tests__/verify-email.page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc5db52c1c8325952b5fd5dc03f6ca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Introduced robust mocks for app navigation and URL query handling to enable deterministic, isolated tests.
  - Centralized Jest setup stubbing navigation hooks, request context, React cache, and IntersectionObserver.
  - Automatically resets mocks before each test to improve reliability and reduce flakiness.
  - Simplifies testing of navigation- and parameter-dependent logic.

- Chores
  - Configured required environment variables for the test runtime to prevent setup errors and ensure consistent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->