### PR TITLE
Add GitHub issue drafts for failing test categories

### DIFF
--- a/tasks/issues/app-router-jest-failures.md
+++ b/tasks/issues/app-router-jest-failures.md
@@ -1,0 +1,36 @@
+# Next.js router-dependent page tests fail with "expected app router to be mounted"
+
+## Summary
+Multiple Jest suites that render Next.js pages/components relying on the App Router fail with invariant violations such as `Invariant: expected app router to be mounted` and React ref warnings. The routing context expected by these components is not available in the test environment, causing each render attempt to throw.
+
+## Impact
+- Blocks automated coverage for key pages (beta signup, forgot password, etc.).
+- Suggests we are mounting App Router components in a test environment configured for the Pages Router.
+- Prevents validation of routing guards, redirects, and other navigation logic.
+
+## Affected tests
+- Any Jest suite rendering App Router components, including:
+  - `__tests__/pages/beta-page.test.tsx`
+  - `__tests__/pages/forgot-password-page.test.tsx`
+  - Additional page-level tests referenced in the failing run output.
+
+## Steps to reproduce
+1. Install dependencies (`npm install`).
+2. Run one of the affected suites: `npm test -- __tests__/pages/beta-page.test.tsx`.
+3. Observe the invariant violation complaining about the App Router not being mounted.
+
+## Expected behaviour
+- Components should render inside a mocked environment that provides the same router context they receive in production.
+- Tests can assert on routing behaviour without runtime crashes.
+
+## Actual behaviour
+- Rendering throws before assertions run, producing invariant and React ref warnings.
+
+## Proposed next steps
+- Introduce a shared helper that wraps App Router components with the appropriate testing harness (e.g., `AppRouterContext.Provider`).
+- Alternatively, refactor tests to mock `next/navigation` hooks (such as `useRouter`) rather than rendering the entire page.
+- Ensure the Jest environment is configured to mimic the App Router runtime expectations.
+- Update failing suites to use the helper and verify rendering completes.
+
+## Additional context
+- These errors were called out in the last `npm test` run summary (67 suites run, 15 failing) and represent a large fraction of the front-end failures.

--- a/tasks/issues/billing-webhook-400.md
+++ b/tasks/issues/billing-webhook-400.md
@@ -1,0 +1,36 @@
+# Billing webhook API tests return HTTP 400 with signature/metadata errors
+
+## Summary
+The Jest suite for the billing webhook endpoint (`__tests__/api/billing/webhook.test.ts`) consistently fails. All mocked webhook deliveries receive HTTP 400 responses and log repeated complaints about invalid Stripe signatures and missing metadata. These errors began surfacing in the latest `npm test` run (67 suites, 15 failing) and affect every scenario in the webhook suite.
+
+## Impact
+- Prevents verification of our Stripe billing webhook handler logic.
+- Blocks confidence in subscription lifecycle flows (checkout completion, invoice payment, cancellation, etc.).
+- Introduces risk of regressions reaching production without automated coverage.
+
+## Affected tests
+- `__tests__/api/billing/webhook.test.ts`
+- Downstream integration expectations in `__tests__/integration/billing-flow.test.ts` that depend on webhook side-effects.
+
+## Steps to reproduce
+1. Install dependencies (`npm install`).
+2. Run the test suite: `npm test -- __tests__/api/billing/webhook.test.ts`.
+3. Observe HTTP 400 responses and repeated log output about signature validation or missing metadata in every case.
+
+## Expected behaviour
+- Each mocked webhook request should be validated, processed, and return HTTP 200.
+- Tests should confirm correct branching logic (subscription created, updated, cancelled, invoice paid, etc.).
+
+## Actual behaviour
+- Handler immediately exits with HTTP 400 for all events.
+- Logs complain about invalid Stripe signatures and absent metadata, preventing the assertions from running.
+
+## Proposed next steps
+- Audit the webhook handler to confirm which headers/body fields it expects during verification.
+- Update the tests to supply a correctly signed payload (potentially by using the Stripe CLI utility for generating signatures or by adjusting mocks to align with handler requirements).
+- Ensure the mocked event payloads include any metadata keys referenced by the handler.
+- Add assertions that confirm a `200` status and correct side-effect behaviour once validation passes.
+
+## Additional context
+- This failure category was one of the major contributors to the 90 failed assertions during the latest `npm test` execution.
+- Addressing the signature validation mismatch should unblock several other billing-related suites.

--- a/tasks/issues/content-loader-async-tests.md
+++ b/tasks/issues/content-loader-async-tests.md
@@ -1,0 +1,40 @@
+# Content loader performance/async tests fail due to environment mismatches
+
+## Summary
+The content loader test suites that verify async behaviour and performance budgets are failing. Observed errors include:
+- Assertions detecting synchronous `fs` calls where async usage is expected.
+- Throughput/latency measurements falling below the target thresholds.
+- jsdom throwing `window.document.addEventListener is not a function` when the loader expects browser APIs.
+
+## Impact
+- Leaves the content ingestion pipeline without automated regression coverage.
+- Indicates that our test environment does not accurately mirror the runtime environment for these modules.
+- Risks shipping performance regressions undetected.
+
+## Affected tests
+- `__tests__/content-loader/performance.test.ts`
+- `__tests__/content-loader/async-behaviour.test.ts`
+- Any other suites referenced in the failure output that import the loader utilities.
+
+## Steps to reproduce
+1. Install dependencies (`npm install`).
+2. Run the content loader suites: `npm test -- __tests__/content-loader`.
+3. Observe the combination of failed performance assertions and missing DOM APIs.
+
+## Expected behaviour
+- Tests should rely on fully async file system mocks or fixtures, so no synchronous calls are detected.
+- Performance expectations should pass with realistic mocked data.
+- Required DOM APIs (e.g., `document.addEventListener`) should be polyfilled in the Jest environment when needed.
+
+## Actual behaviour
+- Assertions flag synchronous `fs` usage and throughput below expectations.
+- jsdom lacks `document.addEventListener`, causing runtime errors.
+
+## Proposed next steps
+- Audit the loader implementation to ensure async APIs are used and to determine whether the tests need updated fixtures.
+- Consider relaxing or parameterising performance thresholds for deterministic outcomes during unit tests.
+- Polyfill or mock any DOM APIs required by the loader before running the suite (e.g., via `jest.setup.ts`).
+- Add regression tests to confirm the mocks behave as expected.
+
+## Additional context
+- These failures were highlighted in the recent `npm test` run (67 suites executed, 15 failing total) and represent the bulk of the remaining assertions after API/page issues are resolved.

--- a/tasks/issues/diagnostic-summary-feature-flag.md
+++ b/tasks/issues/diagnostic-summary-feature-flag.md
@@ -1,0 +1,31 @@
+# Diagnostic summary integration tests crash because `posthog.getFeatureFlag` is undefined
+
+## Summary
+The diagnostic summary client-side integration tests fail early with a runtime error: `posthog.getFeatureFlag is not a function` (or `undefined`). This prevents the diagnostic summary component from rendering inside Jest and causes the suite to abort.
+
+## Impact
+- Blocks regression coverage for the diagnostic summary experience, including gating behaviour driven by feature flags.
+- Indicates our PostHog test double is missing parity with production usage, which may hide other analytics-related defects.
+
+## Affected tests
+- `__tests__/integration/diagnostic-summary.test.tsx` (and any other suite importing the diagnostic summary component).
+
+## Steps to reproduce
+1. Install dependencies (`npm install`).
+2. Run the failing suite: `npm test -- __tests__/integration/diagnostic-summary.test.tsx`.
+3. The component render will throw because `posthog.getFeatureFlag` is not defined on the mocked PostHog client.
+
+## Expected behaviour
+- The PostHog mock exposes a `getFeatureFlag` function returning predictable values for tests.
+- Diagnostic summary tests render successfully and can assert on the UI state.
+
+## Actual behaviour
+- Component rendering throws immediately due to the missing function, causing all assertions to be skipped.
+
+## Proposed next steps
+- Extend the PostHog mock used in tests (likely defined in `jest.setup.ts` or a dedicated mock file) to include `getFeatureFlag` with realistic default behaviour.
+- Audit the component for other PostHog APIs to ensure the mock stays in sync.
+- Add targeted tests that assert the feature-flag-driven branches behave as expected.
+
+## Additional context
+- This issue contributed to multiple integration test failures in the last Jest run (67 suites, 15 failures total).

--- a/tasks/issues/signup-analytics-mock.md
+++ b/tasks/issues/signup-analytics-mock.md
@@ -1,0 +1,33 @@
+# Signup page analytics tests fail due to unexpected arguments on mock calls
+
+## Summary
+The signup page Jest suite is failing because analytics tracking mocks (e.g., Segment/PostHog) receive additional arguments beyond what the assertions expect. The mismatch causes assertions like `toHaveBeenCalledWith` to fail even though the underlying call likely remains correct.
+
+## Impact
+- Blocks automated regression coverage of the signup flow.
+- Indicates our analytics mock expectations are outdated relative to the production implementation.
+- Introduces the risk of real regressions being ignored because the suite is red by default.
+
+## Affected tests
+- `__tests__/pages/signup-page.test.tsx`
+- Any other suite importing the signup component with similar analytics expectations.
+
+## Steps to reproduce
+1. Install dependencies (`npm install`).
+2. Run the suite: `npm test -- __tests__/pages/signup-page.test.tsx`.
+3. Observe assertion failures indicating analytics mocks were called with unexpected extra parameters.
+
+## Expected behaviour
+- Mocks should mirror the live analytics API signature, and assertions should be updated accordingly.
+- Tests should pass when the component triggers analytics with the correct payload.
+
+## Actual behaviour
+- Assertions fail because the mock call arguments include additional metadata or context objects not covered by the test expectations.
+
+## Proposed next steps
+- Inspect the signup component to document the current analytics call signature.
+- Update the Jest mocks to accept the same argument shape, or adjust assertions to use `expect.objectContaining` for flexible matching.
+- Add regression tests for the additional metadata to ensure the payload stays correct in the future.
+
+## Additional context
+- This failure was reported in the last `npm test` execution (67 suites run, 15 failing) as part of the client-side failure set.

--- a/tasks/issues/study-path-api-timeouts.md
+++ b/tasks/issues/study-path-api-timeouts.md
@@ -1,0 +1,34 @@
+# Study path API tests time out and return HTTP 400 instead of 401
+
+## Summary
+The study path API Jest suite times out and asserts against incorrect HTTP responses. Requests that should return `401 Unauthorized` for unauthenticated access instead respond with `400 Bad Request`, and some tests exceed Jest's timeout waiting for a reply.
+
+## Impact
+- Blocks regression coverage for the study path API endpoints.
+- Suggests the handler may be validating input before authentication (returning 400) or misconfigured auth middleware.
+- Timeouts slow down the overall test run and obscure the root cause.
+
+## Affected tests
+- `__tests__/api/study-path/index.test.ts`
+- `__tests__/api/study-path/[id].test.ts`
+
+## Steps to reproduce
+1. Install dependencies (`npm install`).
+2. Run the failing suites: `npm test -- __tests__/api/study-path`.
+3. Observe some tests timing out and others receiving HTTP 400 responses where 401 is expected.
+
+## Expected behaviour
+- Unauthenticated requests should short-circuit with a 401 response.
+- Tests should complete within the configured timeout.
+
+## Actual behaviour
+- Handlers respond with 400 and/or hang until Jest reports a timeout.
+
+## Proposed next steps
+- Review the study path API middleware order to ensure authentication runs before request validation.
+- Add explicit mocks/stubs for authentication helpers in tests to ensure deterministic responses.
+- Investigate whether the handler is awaiting external services that may cause timeouts in Jest.
+- Update tests after the handler behaviour is corrected.
+
+## Additional context
+- These failures were included in the 15 failing suites (90 failed assertions) from the most recent `npm test` execution.

--- a/tasks/issues/supabase-schema-enotfound.md
+++ b/tasks/issues/supabase-schema-enotfound.md
@@ -1,0 +1,34 @@
+# Supabase database schema tests fail with ENOTFOUND to `test.supabase.co`
+
+## Summary
+Database schema validation tests fail because the Supabase client cannot resolve `test.supabase.co`, resulting in `ENOTFOUND` errors. These failures occur early in the test lifecycle, preventing subsequent insert/cascade checks from executing.
+
+## Impact
+- Leaves our Supabase schema migrations unverified by automated tests.
+- Masks potential regressions in row-level security, triggers, and cascading behaviour.
+- Slows local development because each run waits for network DNS timeouts.
+
+## Affected tests
+- `__tests__/billing/database-schema.test.ts`
+- Any other schema verification suites that attempt to connect to the hosted Supabase instance during tests.
+
+## Steps to reproduce
+1. Install dependencies (`npm install`).
+2. Execute the schema tests: `npm test -- __tests__/billing/database-schema.test.ts`.
+3. Observe the `ENOTFOUND test.supabase.co` error emitted by the Supabase client.
+
+## Expected behaviour
+- Tests should run entirely against a local or in-memory Supabase emulator, or the database client should be mocked to avoid network calls.
+- Schema validations should complete without attempting to resolve external DNS entries.
+
+## Actual behaviour
+- Tests attempt to reach `test.supabase.co`, fail DNS resolution, and abort.
+
+## Proposed next steps
+- Decide whether schema tests should run against a local Supabase emulator or be fully mocked.
+- Update test utilities to point to a reachable host (e.g., a dockerised Supabase instance) when running in CI.
+- Alternatively, refactor tests to use static fixtures for schema assertions instead of live connections.
+- Ensure connection parameters are configurable via environment variables for easier overrides during tests.
+
+## Additional context
+- These failures contributed to the 15 failing suites and 90 failed assertions reported in the latest `npm test` execution.


### PR DESCRIPTION
## Summary
- capture the Stripe billing webhook test regressions and recommended fixes
- document diagnostic summary, router, Supabase, content loader, signup analytics, and study path API failure categories as ready-to-file GitHub issues

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cc5a4b8e2883258197a6a7d8cbd3bb