### PR TITLE
Ensure study path auth runs before validation

### DIFF
--- a/__tests__/api.study-path.test.ts
+++ b/__tests__/api.study-path.test.ts
@@ -274,6 +274,11 @@ describe("/api/study-path - TDD RED Phase", () => {
     });
 
     it("should handle malformed JSON", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: { id: "test-user-id" } },
+        error: null,
+      });
+
       const request = new NextRequest("http://localhost:3000/api/study-path", {
         method: "POST",
         body: "invalid json",


### PR DESCRIPTION
## Summary
- run Supabase authentication before parsing or validating request bodies so unauthenticated callers receive 401 responses
- guard against undefined auth responses when checking the user record
- update the malformed JSON unit test to exercise the validation branch with an authenticated user

## Testing
- npx jest __tests__/study-path-api.test.ts __tests__/api.study-path.test.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cc8dc2e2fc8325a9f23b16184a9d8d