### PR TITLE
Restore mobile zoom accessibility by removing restrictive viewport scaling

### DIFF
--- a/__tests__/lib/seo/seo.test.ts
+++ b/__tests__/lib/seo/seo.test.ts
@@ -1,0 +1,12 @@
+import { generateViewport } from "@/lib/seo/seo";
+
+describe("generateViewport", () => {
+  it("allows user zoom by omitting maximumScale", () => {
+    const viewport = generateViewport();
+
+    expect(viewport.width).toBe("device-width");
+    expect(viewport.initialScale).toBe(1);
+    expect("maximumScale" in viewport).toBe(false);
+    expect(viewport.maximumScale).toBeUndefined();
+  });
+});

--- a/lib/seo/seo.ts
+++ b/lib/seo/seo.ts
@@ -136,7 +136,7 @@ export function generateViewport(): Viewport {
   return {
     width: "device-width",
     initialScale: 1,
-    maximumScale: 1,
+    // Intentionally omit maximumScale so that mobile users can zoom
   };
 }
 


### PR DESCRIPTION
## Summary
- **What:** Removed the restrictive `maximumScale` setting from the generated viewport metadata and documented why it remains omitted. Added a Jest unit test to guard against reintroducing the restriction.
- **Why:** Restoring pinch-to-zoom support aligns with mobile accessibility expectations and the audit requirement (P1.1).
- **Files touched:** `lib/seo/seo.ts`, `__tests__/lib/seo/seo.test.ts`
- **Tests:** `npm test -- __tests__/lib/seo/seo.test.ts`
- **Risk:** Low; metadata-only change covered by unit test.
- **Acceptance Criteria:**
  - [x] No `maximumScale: 1` (or `maximum-scale=1`) anywhere in the app.
  - [x] No `user-scalable=no` anywhere.
  - [x] `generateViewport()` returns `width=device-width`, `initialScale=1`, and omits `maximumScale`.
  - [x] `app/layout.tsx` does not introduce a conflicting `<meta name="viewport">`.
  - [x] Unit test covers the viewport object and passes in CI.
  - [ ] (If added) Playwright e2e assertion passes in CI.
  - [x] No new ESLint/TS errors. No measurable CLS introduced (local verification).


------
https://chatgpt.com/codex/tasks/task_e_68ced540c5148325aa97cc598dfcdcd5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restores pinch-to-zoom on mobile by adjusting the viewport configuration, improving accessibility and readability. No impact to desktop behavior.

* **Tests**
  * Added unit tests to verify default viewport settings and confirm the restrictive zoom property is not applied, ensuring consistent behavior across pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->