### PR TITLE
Fix homepage overflow from decorative effects

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -78,7 +78,7 @@ export default function Home() {
   };
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-start bg-gradient-to-b from-slate-50 to-white">
+    <main className="flex min-h-screen flex-col items-stretch justify-start bg-gradient-to-b from-slate-50 to-white">
       {/* Add JSON-LD structured data */}
       <JsonLd />
 
@@ -162,7 +162,7 @@ export default function Home() {
       </LampContainer>
 
       {/* Main content sections */}
-      <div role="main" id="main-content">
+      <div role="main" id="main-content" className="w-full overflow-x-hidden">
         {/* Value Anchors Section */}
         <section className="w-full py-16 px-4 sm:px-6 bg-white">
           <div className="max-w-6xl mx-auto">

--- a/components/marketing/effects/lamp-effect.tsx
+++ b/components/marketing/effects/lamp-effect.tsx
@@ -19,7 +19,7 @@ export const LampContainer = ({
       )}
     >
       {/* Simplified spotlight effects */}
-      <div className="absolute inset-0">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
         {/* Top spotlight */}
         <motion.div
           initial={{ opacity: 0.3, scale: 0.8 }}
@@ -29,9 +29,9 @@ export const LampContainer = ({
             duration: 1.2,
             ease: "easeOut",
           }}
-          className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 w-96 h-96 rounded-full bg-gradient-radial from-orange-500/40 via-orange-500/20 to-transparent blur-3xl"
+          className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[22rem] h-[22rem] rounded-full bg-gradient-radial from-orange-500/40 via-orange-500/20 to-transparent blur-2xl"
         />
-        
+
         {/* Side accent lights */}
         <motion.div
           initial={{ opacity: 0.2, x: -100 }}
@@ -41,9 +41,9 @@ export const LampContainer = ({
             duration: 1.5,
             ease: "easeOut",
           }}
-          className="absolute top-1/2 left-0 -translate-y-1/2 w-64 h-64 rounded-full bg-gradient-radial from-red-500/30 via-red-500/10 to-transparent blur-2xl"
+          className="absolute top-1/2 left-[12%] -translate-x-1/2 -translate-y-1/2 w-48 h-48 rounded-full bg-gradient-radial from-red-500/30 via-red-500/10 to-transparent blur-xl"
         />
-        
+
         <motion.div
           initial={{ opacity: 0.2, x: 100 }}
           whileInView={{ opacity: 0.4, x: 0 }}
@@ -52,7 +52,7 @@ export const LampContainer = ({
             duration: 1.5,
             ease: "easeOut",
           }}
-          className="absolute top-1/2 right-0 -translate-y-1/2 w-64 h-64 rounded-full bg-gradient-radial from-orange-400/30 via-orange-400/10 to-transparent blur-2xl"
+          className="absolute top-1/2 right-[12%] translate-x-1/2 -translate-y-1/2 w-48 h-48 rounded-full bg-gradient-radial from-orange-400/30 via-orange-400/10 to-transparent blur-xl"
         />
       </div>
 

--- a/components/marketing/sections/benefits-section.tsx
+++ b/components/marketing/sections/benefits-section.tsx
@@ -142,14 +142,10 @@ export function BenefitsSectionSkeleton() {
   return (
     <section className="w-full py-10 sm:py-16 md:py-24 px-4 sm:px-6 relative">
       {/* Background element */}
-      <div 
-        className="absolute right-0 top-1/4 -translate-y-1/2 w-64 h-64 bg-blue-50 rounded-full opacity-20 blur-3xl"
-        aria-hidden="true"
-      ></div>
-      <div 
-        className="absolute left-0 bottom-1/4 translate-y-1/2 w-64 h-64 bg-orange-50 rounded-full opacity-20 blur-3xl"
-        aria-hidden="true"
-      ></div>
+      <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
+        <div className="absolute right-[6%] top-1/4 -translate-y-1/2 w-52 h-52 bg-blue-50 rounded-full opacity-30 blur-2xl"></div>
+        <div className="absolute left-[6%] bottom-1/4 translate-y-1/2 w-52 h-52 bg-orange-50 rounded-full opacity-30 blur-2xl"></div>
+      </div>
       
       <div className="max-w-4xl mx-auto text-center space-y-8 relative z-10">
         {/* Skeleton heading */}
@@ -208,22 +204,22 @@ export function BenefitsSection() {
     <section className="w-full py-10 sm:py-16 md:py-24 px-4 sm:px-6 relative">
       {/* Add styles to head for animations */}
       <style jsx global>{`${fadeInUp} ${slideInFromSide} ${pulse}`}</style>
-      
+
       {/* Background element */}
-      <div 
-        className="absolute right-0 top-1/4 -translate-y-1/2 w-64 h-64 bg-blue-50 rounded-full opacity-20 blur-3xl"
-        style={{
-          animation: `pulse 15s ease-in-out infinite alternate`,
-        }}
-        aria-hidden="true"
-      ></div>
-      <div 
-        className="absolute left-0 bottom-1/4 translate-y-1/2 w-64 h-64 bg-orange-50 rounded-full opacity-20 blur-3xl"
-        style={{
-          animation: `pulse 18s ease-in-out infinite alternate-reverse`,
-        }}
-        aria-hidden="true"
-      ></div>
+      <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
+        <div
+          className="absolute right-[6%] top-1/4 -translate-y-1/2 w-52 h-52 bg-blue-50 rounded-full opacity-30 blur-2xl"
+          style={{
+            animation: `pulse 15s ease-in-out infinite alternate`,
+          }}
+        ></div>
+        <div
+          className="absolute left-[6%] bottom-1/4 translate-y-1/2 w-52 h-52 bg-orange-50 rounded-full opacity-30 blur-2xl"
+          style={{
+            animation: `pulse 18s ease-in-out infinite alternate-reverse`,
+          }}
+        ></div>
+      </div>
       
       <div className="max-w-4xl mx-auto text-center space-y-8 relative z-10">
         <h2 

--- a/components/marketing/sections/enhanced-social-proof.tsx
+++ b/components/marketing/sections/enhanced-social-proof.tsx
@@ -136,7 +136,7 @@ export function EnhancedSocialProof() {
           animate={inView ? { opacity: 1 } : { opacity: 0 }}
           transition={{ duration: 0.8, delay: 0.3 }}
         >
-          <Marquee pauseOnHover speed="normal">
+          <Marquee pauseOnHover speed="normal" repeat={2}>
             {socialProofBadges.map((badge, index) => (
               <SocialProofCard key={index} badge={badge} />
             ))}


### PR DESCRIPTION
## Summary
- stretch the main layout wrapper and main-content container so homepage sections cannot extend wider than the viewport
- rein in hero and benefits glow elements with overflow-hidden wrappers and smaller blurred circles to prevent Safari painting overflow
- reduce the social proof marquee track duplication to avoid introducing extra intrinsic width

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cee8fbf4e08325a95208191edd1ec5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Marquee animations now repeat twice for richer motion.

- Style
  - Updated page layout to stretch items, use full-width content, and prevent horizontal scrolling.
  - Refined lamp and background accents (smaller, repositioned, reduced blur) for cleaner visuals.
  - Wrapped visual effect layers to be non-interactive and clipped within the viewport.
  - Harmonized benefits section backgrounds in main and skeleton variants with adjusted sizing, opacity, and pulse animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->