### PR TITLE
Refactor ScoreChart to semantic tokens

### DIFF
--- a/__tests__/components/diagnostic/ScoreChart.test.tsx
+++ b/__tests__/components/diagnostic/ScoreChart.test.tsx
@@ -35,28 +35,43 @@ describe("ScoreChart", () => {
   });
 
   describe("Color coding", () => {
-    it("should use green color for scores >= 70%", () => {
-      render(<ScoreChart score={85} />);
+    it("should use success tone for scores >= 70%", () => {
+      render(<ScoreChart score={85} showStatus />);
 
       const progressCircle = screen.getByTestId("progress-circle");
-      expect(progressCircle).toHaveAttribute("stroke", expect.stringMatching(/22c55e|green/i));
+      const scoreValue = screen.getByText("85%");
+      const status = screen.getByText(/good progress/i);
+
+      expect(progressCircle).toHaveAttribute("stroke", "currentColor");
+      expect(progressCircle).toHaveClass("text-success");
+      expect(scoreValue).toHaveClass("text-success");
+      expect(status).toHaveClass("text-success");
     });
 
-    it("should use orange color for scores 50-69%", () => {
-      render(<ScoreChart score={60} />);
+    it("should use warning tone for scores 50-69%", () => {
+      render(<ScoreChart score={60} showStatus />);
 
       const progressCircle = screen.getByTestId("progress-circle");
-      expect(progressCircle).toHaveAttribute(
-        "stroke",
-        expect.stringMatching(/f59e0b|orange|amber/i)
-      );
+      const scoreValue = screen.getByText("60%");
+      const status = screen.getByText(/keep practicing/i);
+
+      expect(progressCircle).toHaveAttribute("stroke", "currentColor");
+      expect(progressCircle).toHaveClass("text-warning");
+      expect(scoreValue).toHaveClass("text-warning");
+      expect(status).toHaveClass("text-warning");
     });
 
-    it("should use red color for scores < 50%", () => {
-      render(<ScoreChart score={30} />);
+    it("should use error tone for scores < 50%", () => {
+      render(<ScoreChart score={30} showStatus />);
 
       const progressCircle = screen.getByTestId("progress-circle");
-      expect(progressCircle).toHaveAttribute("stroke", expect.stringMatching(/ef4444|red/i));
+      const scoreValue = screen.getByText("30%");
+      const status = screen.getByText(/needs improvement/i);
+
+      expect(progressCircle).toHaveAttribute("stroke", "currentColor");
+      expect(progressCircle).toHaveClass("text-error");
+      expect(scoreValue).toHaveClass("text-error");
+      expect(status).toHaveClass("text-error");
     });
   });
 
@@ -126,19 +141,23 @@ describe("ScoreChart", () => {
 
   describe("Edge cases", () => {
     it("should handle 0% score", () => {
-      render(<ScoreChart score={0} />);
+      render(<ScoreChart score={0} showStatus />);
 
       expect(screen.getByText("0%")).toBeInTheDocument();
       const progressCircle = screen.getByTestId("progress-circle");
-      expect(progressCircle).toHaveAttribute("stroke", expect.stringMatching(/ef4444|red/i));
+      expect(progressCircle).toHaveAttribute("stroke", "currentColor");
+      expect(progressCircle).toHaveClass("text-error");
+      expect(screen.getByText(/needs improvement/i)).toHaveClass("text-error");
     });
 
     it("should handle 100% score", () => {
-      render(<ScoreChart score={100} />);
+      render(<ScoreChart score={100} showStatus />);
 
       expect(screen.getByText("100%")).toBeInTheDocument();
       const progressCircle = screen.getByTestId("progress-circle");
-      expect(progressCircle).toHaveAttribute("stroke", expect.stringMatching(/22c55e|green/i));
+      expect(progressCircle).toHaveAttribute("stroke", "currentColor");
+      expect(progressCircle).toHaveClass("text-success");
+      expect(screen.getByText(/excellent performance|good progress/i)).toHaveClass("text-success");
     });
 
     it("should handle decimal scores by rounding", () => {

--- a/components/diagnostic/ScoreChart.tsx
+++ b/components/diagnostic/ScoreChart.tsx
@@ -9,10 +9,18 @@ interface ScoreChartProps {
   showStatus?: boolean;
 }
 
-function getScoreColor(score: number): string {
-  if (score >= 70) return "#22c55e"; // green
-  if (score >= 50) return "#f59e0b"; // orange/amber
-  return "#ef4444"; // red
+type ScoreTone = "success" | "warning" | "error";
+
+const toneClassMap: Record<ScoreTone, string> = {
+  success: "text-success",
+  warning: "text-warning",
+  error: "text-error",
+};
+
+function getScoreTone(score: number): ScoreTone {
+  if (score >= 70) return "success";
+  if (score >= 50) return "warning";
+  return "error";
 }
 
 function getScoreStatus(score: number): string {
@@ -51,7 +59,8 @@ export const ScoreChart: React.FC<ScoreChartProps> = ({
   const radius = (config.width - config.strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
   const strokeDashoffset = circumference - (displayScore / 100) * circumference;
-  const color = getScoreColor(displayScore);
+  const tone = getScoreTone(displayScore);
+  const toneClass = toneClassMap[tone];
   const performanceLevel = getPerformanceLevel(displayScore);
 
   // Size classes for the container
@@ -81,9 +90,10 @@ export const ScoreChart: React.FC<ScoreChartProps> = ({
             cx={config.width / 2}
             cy={config.height / 2}
             r={radius}
-            stroke="#e5e7eb"
+            stroke="currentColor"
             strokeWidth={config.strokeWidth}
             fill="transparent"
+            className="text-muted"
           />
           {/* Progress circle */}
           <circle
@@ -91,13 +101,16 @@ export const ScoreChart: React.FC<ScoreChartProps> = ({
             cx={config.width / 2}
             cy={config.height / 2}
             r={radius}
-            stroke={color}
+            stroke="currentColor"
             strokeWidth={config.strokeWidth}
             fill="transparent"
             strokeDasharray={circumference}
             strokeDashoffset={animated ? circumference : strokeDashoffset}
             strokeLinecap="round"
-            className={animated ? "transition-all duration-1000 ease-out" : ""}
+            className={cn(
+              animated ? "transition-all duration-1000 ease-out" : "",
+              toneClass,
+            )}
             style={{
               strokeDashoffset: animated ? strokeDashoffset : undefined,
             }}
@@ -106,8 +119,7 @@ export const ScoreChart: React.FC<ScoreChartProps> = ({
         {/* Percentage text in center */}
         <div className="absolute inset-0 flex items-center justify-center">
           <span
-            className={cn(config.fontSize, "font-bold")}
-            style={{ color }}
+            className={cn(config.fontSize, "font-bold", toneClass)}
             aria-live="polite"
             aria-atomic="true"
           >
@@ -117,7 +129,7 @@ export const ScoreChart: React.FC<ScoreChartProps> = ({
       </div>
       {showStatus && (
         <div className="text-center mt-2">
-          <span className="text-sm font-medium" style={{ color }}>
+          <span className={cn("text-sm font-medium", toneClass)}>
             {getScoreStatus(displayScore)}
           </span>
         </div>

--- a/components/diagnostic/__tests__/ScoreChart.test.tsx
+++ b/components/diagnostic/__tests__/ScoreChart.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { ScoreChart } from "../ScoreChart";
+
+describe("ScoreChart", () => {
+  it("uses semantic tone classes without inline color styles", () => {
+    const { rerender } = render(<ScoreChart score={30} showStatus />);
+
+    const getScoreValue = () => screen.getByText(/\d+%/);
+    const getStatusText = () =>
+      screen.getByText(/Excellent Performance|Good Progress|Keep Practicing|Needs Improvement/);
+    const getProgressCircle = () => screen.getByTestId("progress-circle");
+
+    expect(getScoreValue()).toHaveClass("text-error");
+    expect(getScoreValue()).not.toHaveAttribute("style");
+    expect(getStatusText()).toHaveClass("text-error");
+    expect(getStatusText()).not.toHaveAttribute("style");
+    expect(getProgressCircle()).toHaveAttribute("stroke", "currentColor");
+    expect(getProgressCircle()).toHaveClass("text-error");
+
+    rerender(<ScoreChart score={55} showStatus />);
+    expect(getScoreValue()).toHaveClass("text-warning");
+    expect(getStatusText()).toHaveTextContent("Keep Practicing");
+    expect(getProgressCircle()).toHaveClass("text-warning");
+
+    rerender(<ScoreChart score={85} showStatus />);
+    expect(getScoreValue()).toHaveClass("text-success");
+    expect(getStatusText()).toHaveTextContent("Good Progress");
+    expect(getProgressCircle()).toHaveClass("text-success");
+  });
+});

--- a/docs/components/ScoreChart.md
+++ b/docs/components/ScoreChart.md
@@ -1,0 +1,46 @@
+# ScoreChart
+
+The `ScoreChart` component renders a circular progress visualization for diagnostic scores. It now uses semantic design tokens so colors respond correctly in light and dark modes without inline overrides.
+
+## Usage
+
+```tsx
+import { ScoreChart } from "@/components/diagnostic/ScoreChart";
+
+export function DiagnosticSummary() {
+  return (
+    <div className="flex flex-wrap items-center gap-8">
+      <div className="space-y-2">
+        <p className="text-sm text-muted-foreground">Light mode</p>
+        <ScoreChart score={82} showStatus />
+      </div>
+      <div className="space-y-2 rounded-lg bg-background p-4 dark:bg-background">
+        <p className="text-sm text-muted-foreground">Dark mode</p>
+        <div className="dark">
+          <ScoreChart score={42} showStatus />
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+> Wrap a parent element with the `dark` class to preview dark theme tokens locally.
+
+## Tone mapping
+
+| Score range | Tone class      | Semantic intent |
+| ----------- | --------------- | ---------------- |
+| 70 – 100    | `text-success`  | Success / strong performance |
+| 50 – 69     | `text-warning`  | Warning / keep practicing |
+| 0 – 49      | `text-error`    | Error / needs improvement |
+
+The circular stroke and numeric label share the same tone class, while the track uses the neutral `text-muted` token.
+
+## Theming notes
+
+- All colors come from Tailwind semantic tokens (`success`, `warning`, `error`, `muted`).
+- SVG circles use `stroke="currentColor"` so they inherit the tone from their semantic text class.
+- No inline color styles remain, which keeps theming centralized in the design token layer.
+
+This setup ensures the chart automatically adjusts when `.dark` theme variables are active.


### PR DESCRIPTION
## Summary
- derive score tones (success/warning/error) inside `ScoreChart` and map them to semantic Tailwind classes
- ensure SVG strokes and text inherit semantic colors and remove inline color styles; add targeted RTL test and usage docs

## Testing
- `npm test -- ScoreChart`

## Before / After
```diff
- function getScoreColor(score: number): string {
-   if (score >= 70) return "#22c55e";
-   if (score >= 50) return "#f59e0b";
-   return "#ef4444";
- }
+ type ScoreTone = "success" | "warning" | "error";
+
+ function getScoreTone(score: number): ScoreTone {
+   if (score >= 70) return "success";
+   if (score >= 50) return "warning";
+   return "error";
+ }
```

## Ripgrep
```
$ rg -n "(#([0-9A-Fa-f]{3}){1,2}\b|rgba?\(|hsl\()" components/diagnostic/ScoreChart.tsx
```
```
(no matches)
```

_Screenshots not captured in this headless environment._

------
https://chatgpt.com/codex/tasks/task_e_68cf3417c60c8325b2f55ee9fad36fa8