### PR TITLE
Refactor Social Proof badges to tokenized <Badge> component (remove hex/gradients, add a11y)

### DIFF
--- a/app/diagnostic/page.tsx
+++ b/app/diagnostic/page.tsx
@@ -261,7 +261,7 @@ const DiagnosticStartPage = () => {
       <Card className="border-slate-200 shadow-sm p-6 md:p-7">
         <CardHeader className="p-0 mb-6">
           <div className="flex justify-end mb-4">
-            <Badge variant="info" size="sm" className="bg-blue-50 text-blue-700 border-blue-200">
+            <Badge variant="soft" tone="accent" size="sm">
               Updated Oct 2024 exam changes
             </Badge>
           </div>

--- a/components/marketing/sections/enhanced-social-proof.tsx
+++ b/components/marketing/sections/enhanced-social-proof.tsx
@@ -1,80 +1,125 @@
-"use client";
+"use client"
 
-import { motion } from "framer-motion";
-import { useInView } from "react-intersection-observer";
-import { Marquee } from "@/components/marketing/effects/marquee";
-import { Card } from "@/components/ui/card";
-import { colorSemantic } from "@/lib/design-system";
+import { motion } from "framer-motion"
+import { useInView } from "react-intersection-observer"
+
+import { Marquee } from "@/components/marketing/effects/marquee"
+import { Badge, type BadgeProps } from "@/components/ui/badge"
+import { Card } from "@/components/ui/card"
+
+type BadgeTone = NonNullable<BadgeProps["tone"]>
 
 interface SocialProofBadge {
-  icon: React.ReactNode;
-  title: string;
-  subtitle: string;
-  color: string;
+  icon: React.ReactNode
+  title: string
+  subtitle: string
+  tone: BadgeTone
 }
 
 const socialProofBadges: SocialProofBadge[] = [
   {
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className="h-4 w-4"
+      >
         <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
       </svg>
     ),
     title: "14-Day Updates",
     subtitle: "Blueprint Changes",
-    color: "#3B82F6"
+    tone: "accent",
   },
   {
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className="h-4 w-4"
+      >
         <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 0 1-1.043 3.296 3.745 3.745 0 0 1-3.296 1.043A3.745 3.745 0 0 1 12 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 0 1-3.296-1.043 3.745 3.745 0 0 1-1.043-3.296A3.745 3.745 0 0 1 3 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 0 1 1.043-3.296 3.746 3.746 0 0 1 3.296-1.043A3.746 3.746 0 0 1 12 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 0 1 3.296 1.043 3.746 3.746 0 0 1 1.043 3.296A3.745 3.745 0 0 1 21 12Z" />
       </svg>
     ),
     title: "Ex-Google PSO",
     subtitle: "Expert-Built Content",
-    color: "#10B981"
+    tone: "success",
   },
   {
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className="h-4 w-4"
+      >
         <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 14.25v2.25m3-4.5v4.5m3-6.75v6.75m3-9v9M6 20.25h12A2.25 2.25 0 0 0 20.25 18V6A2.25 2.25 0 0 0 18 3.75H6A2.25 2.25 0 0 0 3.75 6v12A2.25 2.25 0 0 0 6 20.25Z" />
       </svg>
     ),
     title: "85% Pass Rate",
     subtitle: "vs 70% Average",
-    color: "#F59E0B"
+    tone: "accent",
   },
   {
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className="h-4 w-4"
+      >
         <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" />
       </svg>
     ),
     title: "15-Min Diagnostic",
     subtitle: "Know Your Readiness",
-    color: "#8B5CF6"
+    tone: "warning",
   },
   {
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className="h-4 w-4"
+      >
         <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
       </svg>
     ),
     title: "40+ Hours Saved",
     subtitle: "Study Efficiently",
-    color: "#EF4444"
+    tone: "accent",
   },
   {
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className="h-4 w-4"
+      >
         <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
       </svg>
     ),
     title: "Free Forever",
     subtitle: "No Credit Card",
-    color: "#059669"
-  }
-];
+    tone: "success",
+  },
+]
 
 const SocialProofCard = ({ badge }: { badge: SocialProofBadge }) => {
   return (
@@ -88,20 +133,21 @@ const SocialProofCard = ({ badge }: { badge: SocialProofBadge }) => {
       initial={{ opacity: 0.8 }}
       whileInView={{ opacity: 1 }}
     >
-      <Card size="sm" className="hover:shadow-lg transition-all duration-200">
-        <div className="flex items-center gap-3">
-          <div 
-            className="w-10 h-10 rounded-full flex items-center justify-center"
-            style={{ backgroundColor: `${badge.color}20` }}
+      <Card
+        size="sm"
+        className="hover:shadow-lg transition-all duration-200 bg-card text-card-foreground border border-border/60"
+      >
+        <div className="flex flex-col gap-3">
+          <Badge
+            size="sm"
+            variant="soft"
+            tone={badge.tone}
+            icon={badge.icon}
+            className="w-fit"
           >
-            <div style={{ color: badge.color }}>
-              {badge.icon}
-            </div>
-          </div>
-          <div>
-            <h3 className="font-semibold text-slate-800 text-sm">{badge.title}</h3>
-            <p className="text-slate-600 text-xs">{badge.subtitle}</p>
-          </div>
+            {badge.title}
+          </Badge>
+          <p className="text-sm text-muted-foreground">{badge.subtitle}</p>
         </div>
       </Card>
     </motion.div>
@@ -115,18 +161,13 @@ export function EnhancedSocialProof() {
   });
 
   return (
-    <section 
-      ref={ref}
-      className="w-full py-12 md:py-16 overflow-hidden"
-      style={{ backgroundColor: colorSemantic.background.default }}
-    >
+    <section ref={ref} className="w-full py-12 md:py-16 overflow-hidden bg-background">
       <div className="max-w-7xl mx-auto px-4 sm:px-6">
-        <motion.h2 
+        <motion.h2
           initial={{ opacity: 0, y: 20 }}
           animate={inView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
           transition={{ duration: 0.6 }}
-          className="text-xl sm:text-2xl md:text-3xl font-semibold text-center mb-12"
-          style={{ color: colorSemantic.text.secondary }}
+          className="text-xl sm:text-2xl md:text-3xl font-semibold text-center mb-12 text-secondary"
         >
           Trusted by Hundreds of Cloud Professionals Worldwide
         </motion.h2>

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,54 +1,181 @@
-"use client";
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
 
-import * as React from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "@/lib/utils"
 
-export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
-  variant?: "default" | "success" | "error" | "warning" | "info";
-  size?: "sm" | "md" | "lg";
-  as?: React.ElementType;
-}
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-full font-medium leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/20 focus-visible:ring-offset-2 focus-visible:ring-offset-background whitespace-nowrap select-none",
+  {
+    variants: {
+      variant: {
+        solid: "shadow-sm",
+        soft: "ring-1 ring-inset",
+        outline: "bg-background ring-1 ring-inset",
+        ghost: "bg-transparent",
+      },
+      tone: {
+        default: "text-foreground",
+        accent: "text-accent",
+        success: "text-success",
+        warning: "text-warning",
+        danger: "text-error",
+      },
+      size: {
+        sm: "h-6 px-2 text-xs gap-1",
+        md: "h-7 px-2.5 text-sm gap-1.5",
+      },
+    },
+    compoundVariants: [
+      {
+        variant: "solid",
+        tone: "default",
+        class: "bg-foreground text-background",
+      },
+      {
+        variant: "solid",
+        tone: "accent",
+        class: "bg-accent text-accent-foreground",
+      },
+      {
+        variant: "solid",
+        tone: "success",
+        class: "bg-success text-background",
+      },
+      {
+        variant: "solid",
+        tone: "warning",
+        class: "bg-warning text-background",
+      },
+      {
+        variant: "solid",
+        tone: "danger",
+        class: "bg-error text-background",
+      },
+      {
+        variant: "soft",
+        tone: "default",
+        class: "bg-muted text-foreground ring-border/60",
+      },
+      {
+        variant: "soft",
+        tone: "accent",
+        class: "bg-accent/10 text-accent ring-accent/20",
+      },
+      {
+        variant: "soft",
+        tone: "success",
+        class: "bg-success/10 text-success ring-success/20",
+      },
+      {
+        variant: "soft",
+        tone: "warning",
+        class: "bg-warning/15 text-warning-dark ring-warning/30",
+      },
+      {
+        variant: "soft",
+        tone: "danger",
+        class: "bg-error/10 text-error ring-error/20",
+      },
+      {
+        variant: "outline",
+        tone: "default",
+        class: "text-foreground ring-border/70",
+      },
+      {
+        variant: "outline",
+        tone: "accent",
+        class: "text-accent ring-accent/40",
+      },
+      {
+        variant: "outline",
+        tone: "success",
+        class: "text-success ring-success/35",
+      },
+      {
+        variant: "outline",
+        tone: "warning",
+        class: "text-warning-dark ring-warning/40",
+      },
+      {
+        variant: "outline",
+        tone: "danger",
+        class: "text-error ring-error/40",
+      },
+      {
+        variant: "ghost",
+        tone: "default",
+        class: "hover:bg-muted/70",
+      },
+      {
+        variant: "ghost",
+        tone: "accent",
+        class: "text-accent hover:bg-accent/10",
+      },
+      {
+        variant: "ghost",
+        tone: "success",
+        class: "text-success hover:bg-success/10",
+      },
+      {
+        variant: "ghost",
+        tone: "warning",
+        class: "text-warning-dark hover:bg-warning/10",
+      },
+      {
+        variant: "ghost",
+        tone: "danger",
+        class: "text-error hover:bg-error/10",
+      },
+    ],
+    defaultVariants: {
+      variant: "soft",
+      tone: "default",
+      size: "md",
+    },
+  }
+)
 
-export const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
-  ({ className, variant = "default", size = "md", as: Component = "div", ...props }, ref) => {
-    // Variant styles using design system tokens via Tailwind classes
-    const variantStyles = {
-      default: "bg-neutral-100 text-neutral-700 border-neutral-200",
-      success: "bg-success-light text-success-dark border-success/40",
-      error: "bg-error-light text-error-dark border-error/40",
-      warning: "bg-warning-light text-warning-dark border-warning/40",
-      info: "bg-info-light text-info-dark border-info/40",
-    };
+const badgeIconVariants = cva("flex items-center justify-center shrink-0", {
+  variants: {
+    size: {
+      sm: "h-3.5 w-3.5",
+      md: "h-4 w-4",
+    },
+  },
+  defaultVariants: {
+    size: "md",
+  },
+})
 
-    // Size styles
-    const sizeStyles = {
-      sm: "text-xs px-2 py-0.5",
-      md: "text-sm px-3 py-1",
-      lg: "text-base px-4 py-1.5",
-    };
+export type BadgeProps = React.HTMLAttributes<HTMLSpanElement> &
+  VariantProps<typeof badgeVariants> & {
+    icon?: React.ReactNode
+    asChild?: boolean
+  }
+
+const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
+  ({ className, variant, tone, size, icon, asChild, children, ...props }, ref) => {
+    const Comp = asChild ? Slot : "span"
 
     return (
-      <Component
+      <Comp
         ref={ref}
-        className={cn(
-          // Base styles
-          "inline-flex items-center justify-center",
-          "rounded-md border font-medium",
-          "transition-colors",
-
-          // Apply variant styles
-          variantStyles[variant],
-
-          // Apply size styles
-          sizeStyles[size],
-
-          // Custom className
-          className
-        )}
+        data-slot="badge"
+        className={cn(badgeVariants({ variant, tone, size }), className)}
         {...props}
-      />
-    );
+      >
+        {icon ? (
+          <span aria-hidden className={badgeIconVariants({ size })}>
+            {icon}
+          </span>
+        ) : null}
+        <span className="truncate">{children}</span>
+      </Comp>
+    )
   }
-);
+)
+Badge.displayName = "Badge"
 
-Badge.displayName = "Badge";
+export { Badge, badgeVariants }
+export default Badge

--- a/docs/design-system/adoptions.md
+++ b/docs/design-system/adoptions.md
@@ -1,0 +1,36 @@
+# Design System Adoptions
+
+## Tokenized Badge component
+
+- Introduced a reusable `<Badge>` component (`components/ui/badge.tsx`) backed by Tailwind semantic tokens for light/dark parity and accessible focus rings.
+- Migrated the Enhanced Social Proof marquee to consume the new Badge, removing inline hex values and bespoke badge styling.
+
+### Usage
+
+**Do**
+
+```tsx
+<Badge variant="soft" tone="accent" size="sm" icon={<SparklesIcon />}>
+  Blueprint Changes
+</Badge>
+```
+
+- Leverage semantic `tone` values (`default`, `accent`, `success`, `warning`, `danger`) to communicate meaning.
+- Use the `icon` slot for decorative glyphs; icons inherit the badge tone automatically.
+- When wrapping interactive elements, pass `asChild` to preserve focus-visible rings.
+
+**Don't**
+
+```tsx
+<span style={{ background: "linear-gradient(90deg, #3B82F6, #2563EB)" }}>
+  Custom Badge
+</span>
+```
+
+- Avoid raw hex/gradient declarations in JSX; rely on design tokens instead.
+- Skip bespoke padding/typography—`size` variants (`sm`, `md`) already meet touch target guidance.
+
+### Adoption Notes
+
+- Enhanced Social Proof badges now use `variant="soft"` with tone-specific rings for both light and dark themes.
+- Future badge/pill surfaces should adopt this component to maintain consistent a11y and token usage.


### PR DESCRIPTION
## Summary
- add a reusable `<Badge>` component with semantic variants, tones, sizes, icon slot, and focus-visible tokenized rings
- refactor the Enhanced Social Proof marquee to consume `<Badge>` and remove inline color styles in favor of design-system tokens
- ensure the diagnostic start page uses a supported `<Badge>` variant so the type system stays in sync
- document badge adoption guidance with do/don't usage examples for future migrations

## Screenshots
- Unable to capture light/dark screenshots locally because the Next.js dev server returns a Supabase credential error without project URL/keys. Please re-run `npm run dev` with valid Supabase environment variables to generate updated imagery.

## Testing
- `npm run lint`
- `npx tsc --noEmit`

## Verification
- `rg -n "(#(?:[0-9A-Fa-f]{3}){1,2}\b|rgba?\(|linear-gradient\()" components/marketing/sections/enhanced-social-proof.tsx`
- `rg -n "<Badge" components/marketing/sections/enhanced-social-proof.tsx`

## Follow-ups
- Migrate other badge/pill treatments across marketing surfaces to the new `<Badge>` component.
- Consider adding lint automation to flag raw hex usage in JSX once the broader migration lands.


------
https://chatgpt.com/codex/tasks/task_e_68cf36d0147883259905f4ab61cbdc41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced a configurable Badge with tone-based variants, sizes, and optional icons for consistent theming and readability.

* UI Updates
  * Enhanced Social Proof section redesigned with badges, refined backgrounds, borders, and typography for clearer hierarchy and improved legibility.
  * Smaller, cleaner icons and simplified layout for better scanability.
  * Diagnostic page notice updated to a softer, accent-toned small badge.

* Documentation
  * Added a Design System Adoptions guide outlining Badge usage, best practices, and migration notes with examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->