### PR TITLE
ci(storybook): add PR Storybook build + artifact

### DIFF
--- a/.github/workflows/storybook-ci.yml
+++ b/.github/workflows/storybook-ci.yml
@@ -1,0 +1,87 @@
+name: Storybook CI
+
+on:
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  storybook-build:
+    name: Build Storybook (PR)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect package manager
+        id: pm
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            echo "manager=pnpm" >> "$GITHUB_OUTPUT"
+            echo "lock=pnpm-lock.yaml" >> "$GITHUB_OUTPUT"
+          elif [ -f package-lock.json ]; then
+            echo "manager=npm" >> "$GITHUB_OUTPUT"
+            echo "lock=package-lock.json" >> "$GITHUB_OUTPUT"
+          else
+            echo "manager=npm" >> "$GITHUB_OUTPUT"
+            echo "lock=package-lock.json" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Detect Node version file
+        id: node-version
+        run: |
+          if [ -f .nvmrc ]; then
+            echo "use-file=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "use-file=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node (nvmrc)
+        if: ${{ steps.node-version.outputs.use-file == 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: ${{ steps.pm.outputs.manager }}
+          cache-dependency-path: ${{ steps.pm.outputs.lock }}
+
+      - name: Setup Node
+        if: ${{ steps.node-version.outputs.use-file != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: ${{ steps.pm.outputs.manager }}
+          cache-dependency-path: ${{ steps.pm.outputs.lock }}
+
+      - name: Install dependencies
+        run: |
+          if [ "${{ steps.pm.outputs.manager }}" = "pnpm" ]; then
+            corepack enable
+            pnpm install --frozen-lockfile
+          else
+            npm ci
+          fi
+
+      - name: Verify Storybook presence
+        run: |
+          if [ "${{ steps.pm.outputs.manager }}" = "pnpm" ]; then
+            pnpm storybook:verify
+          else
+            npm run storybook:verify
+          fi
+
+      - name: Build Storybook
+        run: |
+          if [ "${{ steps.pm.outputs.manager }}" = "pnpm" ]; then
+            pnpm storybook:build
+          else
+            npm run storybook:build
+          fi
+
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook-static
+          path: storybook-static
+          if-no-files-found: error
+          retention-days: 7

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing Guide
+
+## Storybook in CI
+
+Our pull request workflow now builds Storybook headlessly so reviewers can explore the component catalogue without running it locally.
+
+### Running Storybook locally
+
+- `npm run storybook` – start Storybook in development mode on port 6006.
+- `npm run storybook:verify` – confirm that the `.storybook/` directory exists; CI fails fast with the same command if Storybook has not been bootstrapped yet.
+- `npm run storybook:build` – create a production build in `storybook-static/` that matches what CI uploads.
+
+> If you are using pnpm locally, replace `npm run` with `pnpm` when executing the commands above.
+
+### What CI does
+
+1. Detects whether the repo uses npm or pnpm and installs dependencies accordingly.
+2. Verifies that `.storybook/` is present. If it is missing, the workflow stops with the message: `Storybook not found: bootstrap it before CI (Task 5).`
+3. Runs the headless Storybook build (`storybook build`) and uploads the generated `storybook-static/` directory as an artifact named **storybook-static**.
+
+To download the artifact on a pull request, open the PR → **Checks** tab → select **Storybook CI** → scroll to **Artifacts** → download **storybook-static**. Unzip the archive locally and serve it with any static file server (e.g. `npx http-server storybook-static`).
+
+### Troubleshooting
+
+- **`.storybook` missing:** Run the Task 5 bootstrap (or copy an existing configuration) before re-running CI.
+- **Story or MDX build failures:** Run `npm run storybook` locally to inspect the error output and ensure MDX/CSF stories compile without warnings.
+- **Broken assets in the static build:** When importing local assets, use paths relative to the `public/` directory or configure `storybook build` with the correct `--static-dir` option.
+
+### Version notes
+
+Storybook v8+ uses the `storybook build` command, which our `storybook:build` script runs today. If you downgrade to Storybook v7, switch the script to `build-storybook -s public -o storybook-static` to maintain CI compatibility.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "validate:content": "NODE_NO_WARNINGS=1 node scripts/validate-content.js",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
+    "storybook:verify": "node -e \"const fs=require('fs'); if(!fs.existsSync('.storybook')){console.error('Storybook not found: bootstrap it before CI (Task 5).'); process.exit(2)} else {console.log('Storybook config found.')}\"",
     "storybook:preview": "http-server storybook-static -p 6007 -c-1",
     "test": "jest",
     "e2e": "playwright test",


### PR DESCRIPTION
## Summary
- add a Storybook CI workflow that detects the package manager, installs dependencies, verifies configuration, builds, and uploads the static artifact on pull requests
- add a Storybook verification script alongside the existing headless build script for consistent CI usage
- document the new Storybook CI process, artifact download steps, and troubleshooting guidance in docs/CONTRIBUTING.md

## Testing
- npm run storybook:verify
- npm run storybook:build

------
https://chatgpt.com/codex/tasks/task_e_68cf690609288325a0e69583832c7f7d