### PR TITLE
feat: add section layout primitive

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "../styles/tokens.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -18,7 +18,7 @@ import { usePostHog } from "posthog-js/react";
 import { trackEvent, ANALYTICS_EVENTS } from "@/lib/analytics/analytics";
 import { PricingCard } from "@/components/pricing/PricingCard";
 import { ComparisonTable } from "@/components/pricing/ComparisonTable";
-import { Container } from "@/components/patterns";
+import { Container, Section } from "@/components/patterns";
 import {
   SUBSCRIPTION_TIERS,
   EXAM_PACKAGES,
@@ -125,7 +125,12 @@ export default function PricingPage() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
       {/* Hero Section with Value Proposition */}
-      <div className="relative overflow-hidden bg-gradient-to-br from-blue-600 via-blue-700 to-cyan-600 text-white py-16 sm:py-24">
+      <Section
+        contained={false}
+        size="xl"
+        surface="brand"
+        className="relative overflow-hidden bg-gradient-to-br from-blue-600 via-blue-700 to-cyan-600 text-white"
+      >
         <div className="absolute inset-0 bg-grid-white/10 [mask-image:linear-gradient(0deg,transparent,rgba(255,255,255,0.1))]" />
         <Container className="relative">
           <div className="text-center">
@@ -160,7 +165,7 @@ export default function PricingPage() {
             </div>
           </div>
         </Container>
-      </div>
+      </Section>
 
       {/* Error Alert */}
       {error && (
@@ -211,7 +216,12 @@ export default function PricingPage() {
       </Container>
 
       {/* Main Pricing Cards */}
-      <Container className="py-16">
+      <Section
+        id="pricing-cards"
+        size="xl"
+        surface="subtle"
+        divider="both"
+      >
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 lg:gap-10">
           {SUBSCRIPTION_TIERS.map((tier) => (
             <PricingCard
@@ -269,11 +279,11 @@ export default function PricingPage() {
             ))}
           </div>
         )}
-      </Container>
+      </Section>
 
       {/* AI Credits Explanation */}
-      <div className="bg-blue-50 py-12">
-        <Container className="max-w-4xl">
+      <Section size="lg" surface="subtle" divider="bottom">
+        <div className="mx-auto max-w-4xl">
           <div className="text-center mb-8">
             <h2 className="text-2xl font-bold text-gray-900 mb-4">How AI Credits Work</h2>
             <p className="text-gray-600">
@@ -309,12 +319,11 @@ export default function PricingPage() {
             Need more credits? Purchase additional at ${AI_CREDIT_USAGE.additionalCreditPrice}
             /credit or upgrade your plan
           </p>
-        </Container>
-      </div>
+        </div>
+      </Section>
 
       {/* Social Proof Section */}
-      <div className="py-16 bg-white">
-        <Container>
+      <Section size="lg" surface="default">
           <h2 className="text-3xl font-bold text-center text-gray-900 mb-12">
             Trusted by Cloud Professionals Worldwide
           </h2>
@@ -337,12 +346,10 @@ export default function PricingPage() {
               </div>
             ))}
           </div>
-        </Container>
-      </div>
+      </Section>
 
       {/* Feature Comparison */}
-      <div className="py-16 bg-gray-50">
-        <Container>
+      <Section size="lg" surface="subtle" divider="bottom">
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">Compare Plans in Detail</h2>
             <button
@@ -374,12 +381,11 @@ export default function PricingPage() {
               }}
             />
           )}
-        </Container>
-      </div>
+      </Section>
 
       {/* FAQ Section */}
-      <div className="py-16 bg-white">
-        <Container className="max-w-3xl">
+      <Section size="lg" surface="default" divider="bottom">
+        <div className="mx-auto max-w-3xl">
           <h2 className="text-3xl font-bold text-center text-gray-900 mb-12">
             Frequently Asked Questions
           </h2>
@@ -405,12 +411,18 @@ export default function PricingPage() {
               </div>
             ))}
           </div>
-        </Container>
-      </div>
+        </div>
+      </Section>
 
       {/* Final CTA */}
-      <div className="bg-gradient-to-r from-blue-600 to-cyan-600 py-16">
-        <Container className="max-w-4xl text-center">
+      <Section
+        contained={false}
+        size="xl"
+        surface="brand"
+        divider="top"
+        className="bg-gradient-to-r from-blue-600 to-cyan-600"
+      >
+        <Container className="max-w-4xl text-center text-white">
           <h2 className="text-3xl font-bold text-white mb-4">Ready to Pass Your Certification?</h2>
           <p className="text-xl text-blue-100 mb-8">
             Join thousands of professionals who achieved their certification goals with Testero
@@ -437,10 +449,9 @@ export default function PricingPage() {
             <span>30-day money-back guarantee on all plans</span>
           </div>
         </Container>
-      </div>
+      </Section>
 
-      {/* Pricing Cards Anchor */}
-      <div id="pricing-cards" className="absolute -top-20"></div>
+      {/* Pricing Cards Anchor handled via Section id */}
     </div>
   );
 }

--- a/components/marketing/sections/enhanced-social-proof.tsx
+++ b/components/marketing/sections/enhanced-social-proof.tsx
@@ -4,7 +4,7 @@ import { motion } from "framer-motion"
 import { useInView } from "react-intersection-observer"
 
 import { Marquee } from "@/components/marketing/effects/marquee"
-import { Container } from "@/components/patterns"
+import { Section } from "@/components/patterns"
 import { Badge, type BadgeProps } from "@/components/ui/badge"
 import { Card } from "@/components/ui/card"
 
@@ -162,29 +162,27 @@ export function EnhancedSocialProof() {
   });
 
   return (
-    <section ref={ref} className="w-full py-12 md:py-16 overflow-hidden bg-background">
-      <Container>
-        <motion.h2
-          initial={{ opacity: 0, y: 20 }}
-          animate={inView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
-          transition={{ duration: 0.6 }}
-          className="text-xl sm:text-2xl md:text-3xl font-semibold text-center mb-12 text-secondary"
-        >
-          Trusted by Hundreds of Cloud Professionals Worldwide
-        </motion.h2>
-        
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={inView ? { opacity: 1 } : { opacity: 0 }}
-          transition={{ duration: 0.8, delay: 0.3 }}
-        >
-          <Marquee pauseOnHover speed="normal" repeat={2}>
-            {socialProofBadges.map((badge, index) => (
-              <SocialProofCard key={index} badge={badge} />
-            ))}
-          </Marquee>
-        </motion.div>
-      </Container>
-    </section>
+    <Section ref={ref} size="lg" surface="default" className="overflow-hidden">
+      <motion.h2
+        initial={{ opacity: 0, y: 20 }}
+        animate={inView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
+        transition={{ duration: 0.6 }}
+        className="text-xl sm:text-2xl md:text-3xl font-semibold text-center mb-12 text-secondary"
+      >
+        Trusted by Hundreds of Cloud Professionals Worldwide
+      </motion.h2>
+
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={inView ? { opacity: 1 } : { opacity: 0 }}
+        transition={{ duration: 0.8, delay: 0.3 }}
+      >
+        <Marquee pauseOnHover speed="normal" repeat={2}>
+          {socialProofBadges.map((badge, index) => (
+            <SocialProofCard key={index} badge={badge} />
+          ))}
+        </Marquee>
+      </motion.div>
+    </Section>
   );
 }

--- a/components/patterns/__tests__/section.test.tsx
+++ b/components/patterns/__tests__/section.test.tsx
@@ -1,0 +1,46 @@
+import { render } from "@testing-library/react"
+
+import { Section } from "../section"
+
+describe("Section", () => {
+  it("renders with default variants and container", () => {
+    const { container } = render(<Section>Content</Section>)
+
+    const section = container.querySelector("section")
+    expect(section).toBeInTheDocument()
+    expect(section).toHaveClass("bg-surface")
+
+    const inner = section?.querySelector(":scope > div")
+    expect(inner).toHaveClass("py-section_lg")
+
+    const contained = inner?.firstElementChild as HTMLElement | null
+    expect(contained).toHaveClass("mx-auto")
+    expect(contained?.textContent).toBe("Content")
+  })
+
+  it("supports variant overrides and uncontained layout", () => {
+    const { container } = render(
+      <Section
+        as="article"
+        size="sm"
+        surface="muted"
+        divider="both"
+        contained={false}
+        className="custom"
+      >
+        <p>Inner content</p>
+      </Section>,
+    )
+
+    const section = container.querySelector("article")
+    expect(section).toBeInTheDocument()
+    expect(section).toHaveClass("bg-surface-muted", "border-y", "border-divider", "custom")
+
+    const inner = section?.querySelector(":scope > div")
+    expect(inner).toHaveClass("py-section_sm")
+
+    const contained = inner?.firstElementChild as HTMLElement | null
+    expect(contained).not.toHaveClass("mx-auto")
+    expect(contained?.tagName.toLowerCase()).toBe("p")
+  })
+})

--- a/components/patterns/index.ts
+++ b/components/patterns/index.ts
@@ -1,1 +1,2 @@
 export * from "./Container"
+export * from "./section"

--- a/components/patterns/section.stories.tsx
+++ b/components/patterns/section.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { Button } from "@/components/ui/button"
+
+import { Section } from "./section"
+
+const meta = {
+  title: "Patterns/Section",
+  component: Section,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Reusable layout primitive that standardises vertical rhythm, background surfaces, and optional dividers.",
+      },
+    },
+  },
+  args: {
+    size: "lg",
+    surface: "default",
+    divider: "none",
+    contained: true,
+  },
+  argTypes: {
+    size: {
+      control: { type: "inline-radio" },
+      options: ["sm", "md", "lg", "xl"],
+    },
+    surface: {
+      control: { type: "select" },
+      options: ["default", "subtle", "muted", "elevated", "brand"],
+    },
+    divider: {
+      control: { type: "inline-radio" },
+      options: ["none", "top", "bottom", "both"],
+    },
+    contained: {
+      control: { type: "boolean" },
+    },
+  },
+} satisfies Meta<typeof Section>
+
+export default meta
+
+type Story = StoryObj<typeof Section>
+
+export const Playground: Story = {
+  render: (args) => (
+    <Section {...args}>
+      <div className="space-y-6">
+        <div className="max-w-2xl space-y-3">
+          <h2 className="text-3xl font-semibold tracking-tight">Consistent rhythm</h2>
+          <p className="text-muted-foreground">
+            Use semantic spacing, surfaces, and dividers to maintain predictable vertical rhythm across pages. Toggle the
+            controls to preview each variant, including dark mode via the toolbar theme switcher.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-4">
+          <Button size="lg">Primary action</Button>
+          <Button size="lg" variant="outline">
+            Secondary
+          </Button>
+        </div>
+      </div>
+    </Section>
+  ),
+}
+
+export const FullBleed: Story = {
+  args: {
+    contained: false,
+    surface: "brand",
+    size: "xl",
+    divider: "both",
+  },
+  render: (args) => (
+    <Section {...args} className="overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-br from-blue-600 via-blue-700 to-cyan-600 opacity-90" />
+      <div className="relative">
+        <div className="py-section_lg">
+          <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 text-center text-white">
+            <h2 className="text-4xl font-bold tracking-tight">Full-bleed hero</h2>
+            <p className="mt-4 text-lg text-blue-100">
+              Combine the Section primitive with your own layout primitives for wide experiences while preserving rhythm and
+              divider tokens.
+            </p>
+          </div>
+        </div>
+      </div>
+    </Section>
+  ),
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+}

--- a/components/patterns/section.tsx
+++ b/components/patterns/section.tsx
@@ -1,0 +1,95 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+import { Container } from "./Container"
+
+const outer = cva("relative w-full", {
+  variants: {
+    surface: {
+      default: "bg-surface",
+      subtle: "bg-surface-subtle",
+      muted: "bg-surface-muted",
+      elevated: "bg-surface-elevated shadow-sm",
+      brand: "bg-surface-brand",
+    },
+    divider: {
+      none: "",
+      top: "border-t border-divider",
+      bottom: "border-b border-divider",
+      both: "border-y border-divider",
+    },
+  },
+  defaultVariants: { surface: "default", divider: "none" },
+})
+
+const inner = cva("w-full", {
+  variants: {
+    size: {
+      sm: "py-section_sm",
+      md: "py-section_md",
+      lg: "py-section_lg",
+      xl: "py-section_xl",
+    },
+  },
+  defaultVariants: { size: "lg" },
+})
+
+type SectionElement =
+  | "section"
+  | "div"
+  | "header"
+  | "footer"
+  | "main"
+  | "article"
+  | "aside"
+
+export type SectionProps<T extends SectionElement = "section"> = {
+  as?: T
+  contained?: boolean
+  className?: string
+  children?: React.ReactNode
+} & VariantProps<typeof outer> &
+  VariantProps<typeof inner> &
+  Omit<React.ComponentPropsWithoutRef<T>, "as" | "className" | "children">
+
+type SectionComponent = <T extends SectionElement = "section">(
+  props: SectionProps<T> & { ref?: React.Ref<React.ElementRef<T>> },
+) => React.ReactElement | null
+
+const SectionBase = React.forwardRef(
+  <T extends SectionElement = "section">(
+    props: SectionProps<T>,
+    ref: React.Ref<React.ElementRef<T>>,
+  ) => {
+    const {
+      as,
+      surface,
+      divider,
+      size,
+      contained = true,
+      className,
+      children,
+      ...rest
+    } = props
+
+    const Component = (as ?? "section") as React.ElementType
+
+    return (
+      <Component
+        ref={ref}
+        className={cn(outer({ surface, divider }), className)}
+        {...rest}
+      >
+        <div className={cn(inner({ size }))}>
+          {contained ? <Container>{children}</Container> : children}
+        </div>
+      </Component>
+    )
+  },
+)
+
+SectionBase.displayName = "Section"
+
+export const Section = SectionBase as SectionComponent

--- a/components/sections/TrustedBySection.tsx
+++ b/components/sections/TrustedBySection.tsx
@@ -4,15 +4,13 @@ import React from "react";
 import Image from "next/image";
 import { cn } from "@/lib/utils";
 import { Marquee } from "@/components/marketing/effects/marquee";
-import { Container } from "@/components/patterns";
+import { Section } from "@/components/patterns";
 import { partners, type Partner } from "@/data/partners";
 
 // Component-specific design tokens following the design system
 const designTokens = {
   colors: {
     // Using design system color tokens
-    background: "bg-white dark:bg-slate-950",
-    surface: "bg-white dark:bg-slate-900",
     text: {
       primary: "text-slate-800 dark:text-white",
       secondary: "text-slate-600 dark:text-slate-400",
@@ -30,7 +28,6 @@ const designTokens = {
     logoTitle: "text-sm font-semibold",
   },
   spacing: {
-    section: "py-16 md:py-20",
     logo: "h-12 md:h-16",
     logoContainer: "h-20 md:h-24",
   },
@@ -127,16 +124,13 @@ export function TrustedBySection({
   const marqueeSpeed = prefersReducedMotion ? "slow" : speed;
 
   return (
-    <section
-      className={cn(
-        designTokens.colors.background,
-        isCompact ? "py-8 md:py-12" : designTokens.spacing.section,
-        className
-      )}
+    <Section
       role="region"
       aria-label="Our trusted partners"
+      size={isCompact ? "md" : "xl"}
+      surface="default"
+      className={className}
     >
-      <Container>
         {/* Header */}
         <div className="text-center mb-8 md:mb-12">
           <h2
@@ -230,8 +224,7 @@ export function TrustedBySection({
             </p>
           </div>
         )}
-      </Container>
-    </section>
+    </Section>
   );
 }
 

--- a/docs/pr-008-section-primitive.md
+++ b/docs/pr-008-section-primitive.md
@@ -1,0 +1,72 @@
+# Section Primitive Rollout
+
+## Summary
+- Added a reusable `<Section>` layout primitive with typed variants for rhythm (`size`), background surfaces (`surface`), and dividers (`divider`).
+- Introduced tokenised spacing and surface variables so Tailwind can generate semantic utilities (`py-section_lg`, `bg-surface-muted`, etc.).
+- Documented the component in Storybook with interactive controls and dark-mode preview, plus unit tests for variant composition.
+- Migrated representative marketing surfaces (pricing page, trusted-by carousel, enhanced social proof) to validate the API and remove ad-hoc `py-16` patterns.
+- Added an ESLint helper that nudges authors toward the primitive when legacy section padding classes appear.
+
+## Component API
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `size` | `"sm" \| "md" \| "lg" \| "xl"` | `"lg"` | Maps to `py-section_*` spacing tokens (24/32/48/64px). |
+| `surface` | `"default" \| "subtle" \| "muted" \| "elevated" \| "brand"` | `"default"` | Applies semantic surfaces backed by CSS variables. `elevated` includes a shadow token. |
+| `divider` | `"none" \| "top" \| "bottom" \| "both"` | `"none"` | Uses the divider color token so borders adapt to themes. |
+| `contained` | `boolean` | `true` | Wraps children in the shared `Container` primitive (max-width + responsive padding). Set `false` for full-bleed layouts. |
+| `as` | block-level element | `"section"` | Polymorphic tag support for semantic markup. |
+| `className` | `string` | — | Merged with computed variants via `cn`. |
+
+### Usage Examples
+```tsx
+<Section size="lg" surface="default">
+  <PageHeader title="Pricing" description="Choose the plan that fits." />
+</Section>
+
+<Section size="xl" surface="subtle" divider="top">
+  <FeaturesGrid />
+</Section>
+
+<Section size="md" surface="brand" divider="both" contained={false}>
+  <WideHero />
+</Section>
+```
+
+## Design Tokens & Tailwind Extensions
+- Added `styles/tokens.css` with CSS variables for section rhythm (`--section-sm` → `--section-xl`), surface aliases (`--surface-default`, `--surface-brand`, etc.), and the shared divider color.
+- Imported the token sheet from `app/globals.css` so the variables flow to every theme.
+- Extended `tailwind.config.ts` to expose the new spacing keys (`section_sm` → `section_xl`) and semantic colors (`surface.*`, `divider`). This allows ergonomics like `py-section_md` or `bg-surface-muted` across the app.
+
+## Storybook & Tests
+- `components/patterns/section.stories.tsx` showcases the primitive with controls for every variant and a full-bleed example. The global theme toolbar handles light/dark previews.
+- `components/patterns/__tests__/section.test.tsx` verifies default/variant class composition and the `contained` behaviour.
+
+## Migrated Sections (Before → After)
+### `app/pricing/page.tsx`
+- **Before:** Each band used bespoke wrappers like `<div className="py-16 bg-gray-50">` or `<Container className="py-16">`.
+- **After:** `<Section>` instances handle the hero, pricing cards, AI credits, social proof, comparison grid, FAQ, and CTA—with semantic surfaces (`surface="subtle"`) and dividers that align to the design system.
+
+### `components/sections/TrustedBySection.tsx`
+- **Before:** Component-level token map defined `spacing.section = "py-16 md:py-20"` and rendered a raw `<section>`.
+- **After:** `<Section size={isCompact ? "md" : "xl"}>` provides rhythm while the component focuses on marquee logic. Local spacing tokens now only cover logo sizing.
+
+### `components/marketing/sections/enhanced-social-proof.tsx`
+- **Before:** Manual `py-12 md:py-16` and a standalone `<Container>`.
+- **After:** `<Section size="lg">` wraps the content, keeps the shared container padding, and still works with the `useInView` ref.
+
+## Migration Checklist
+1. Replace `div`/`section` wrappers that only provide vertical padding or background colour with `<Section>`.
+2. Choose a `size` token that matches the intent (`lg` for 48px, `xl` for 64px). Avoid re-adding raw `py-16` utilities.
+3. Pick a `surface` variant instead of hard-coded `bg-*` utilities when possible.
+4. Enable dividers via `divider="top"|"bottom"|"both"` rather than manual `border-t` strings.
+5. Leave `contained` at the default unless a section needs to be full-bleed—then supply your own inner wrapper (e.g., `<Container>` or custom grid).
+6. Delete redundant local spacing tokens once `<Section>` is in place.
+
+## ESLint Assist
+A `no-restricted-syntax` rule warns when class strings contain the legacy section padding utilities (`py-16`, `md:py-20`, etc.). Use `<Section size="lg" />` instead. If a one-off layout genuinely requires the old pattern, add `// eslint-disable-next-line no-restricted-syntax` above the JSX attribute with justification.
+
+## Testing & Verification
+- `npm run lint`
+- `npm run test`
+- `npm run build`
+- `npm run storybook:build`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,8 +9,23 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
+const sectionPaddingSelector =
+  "JSXAttribute[name.name='className'][value.type='Literal'][value.value=/\\b(?:sm:|md:|lg:|xl:)?py-(?:16|20|24|32)\\b/]"
+
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    rules: {
+      "no-restricted-syntax": [
+        "warn",
+        {
+          selector: sectionPaddingSelector,
+          message:
+            "Use the <Section> primitive for vertical rhythm instead of ad-hoc py-16/py-20 patterns. Add // eslint-disable-next-line no-restricted-syntax for intentional overrides.",
+        },
+      ],
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,0 +1,27 @@
+:root {
+  /* Section vertical rhythm */
+  --section-sm: 1.5rem; /* 24px */
+  --section-md: 2rem; /* 32px */
+  --section-lg: 3rem; /* 48px */
+  --section-xl: 4rem; /* 64px */
+
+  /* Surface aliases */
+  --bg: var(--background);
+  --fg: var(--foreground);
+  --surface-default: var(--background);
+  --surface-subtle: color-mix(in oklch, var(--background) 92%, var(--foreground) 8%);
+  --surface-muted: color-mix(in oklch, var(--muted) 85%, var(--background) 15%);
+  --surface-elevated: var(--card, var(--background));
+  --surface-brand: color-mix(in oklch, var(--accent) 6%, transparent);
+
+  /* Divider */
+  --divider-color: color-mix(in oklch, var(--foreground) 12%, transparent);
+}
+
+.dark {
+  --surface-subtle: color-mix(in oklch, var(--background) 88%, var(--foreground) 12%);
+  --surface-muted: color-mix(in oklch, var(--muted) 60%, var(--background) 40%);
+  --surface-elevated: var(--card, var(--background));
+  --surface-brand: color-mix(in oklch, var(--accent) 10%, transparent);
+  --divider-color: color-mix(in oklch, var(--foreground) 18%, transparent);
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -104,10 +104,25 @@ const config = {
           DEFAULT: colorSemantic.info.base,
           dark: colorSemantic.info.dark,
         },
+
+        surface: {
+          DEFAULT: "var(--surface-default)",
+          subtle: "var(--surface-subtle)",
+          muted: "var(--surface-muted)",
+          elevated: "var(--surface-elevated)",
+          brand: "var(--surface-brand)",
+        },
+        divider: "var(--divider-color)",
       },
 
       // Spacing scale from design system
-      spacing: spacingPrimitive,
+      spacing: {
+        ...spacingPrimitive,
+        section_sm: "var(--section-sm)",
+        section_md: "var(--section-md)",
+        section_lg: "var(--section-lg)",
+        section_xl: "var(--section-xl)",
+      },
 
       // Typography
       fontFamily: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
     "__tests__",
     "**/*.test.ts",
     "**/*.test.tsx",
+    "**/*.stories.tsx",
     "stories/**/*"
   ]
 }


### PR DESCRIPTION
## Summary
- introduce a reusable `<Section>` primitive with semantic spacing, surfaces, and divider variants and wire the new tokens into Tailwind
- document, test, and showcase the component in Storybook while tightening linting to discourage ad-hoc section padding
- migrate pricing, trusted-by, and social proof surfaces onto the primitive and capture the rollout plan in docs/pr-008-section-primitive.md

## Testing
- `npm run lint`
- `npm run test` *(fails: existing suite hits ESM-only dependency `uncrypto` and other pre-existing issues – see console for details)*
- `CI=1 npm run build`
- `npm run storybook:build` *(fails: `storybook` binary not present in node_modules)*

## Checklist
- [x] Section primitive created with tokens and variants
- [x] Storybook story with controls + dark mode preview
- [x] 3+ call-sites migrated (pricing page, trusted-by section, social proof)
- [x] No raw hex/arbitrary spacing introduced
- [ ] Tests added/passing (unit/a11y)
- [x] docs/pr-008-section-primitive.md added with API + migration notes

------
https://chatgpt.com/codex/tasks/task_e_68cff51a74d08325ac8a0d07fb5d5115