### PR TITLE
fix(design-system): resolve storybook typing issues

### DIFF
--- a/__tests__/components/ui/EmptyState.test.tsx
+++ b/__tests__/components/ui/EmptyState.test.tsx
@@ -1,0 +1,34 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+
+import { EmptyState } from "@/components/ui/empty-state"
+
+describe("EmptyState", () => {
+  it("renders actions with appropriate labels", () => {
+    render(
+      <EmptyState
+        title="No diagnostics yet"
+        description="Create your first diagnostic to compare baselines."
+        primaryAction={{ label: "New diagnostic", onClick: jest.fn() }}
+        secondaryAction={{ label: "Import data", onClick: jest.fn() }}
+      />
+    )
+
+    expect(screen.getByRole("status")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "New diagnostic" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Import data" })).toBeInTheDocument()
+  })
+
+  it("elevates severity for danger tone", () => {
+    render(
+      <EmptyState
+        tone="danger"
+        title="Upload failed"
+        description="Check the template and try again."
+      />
+    )
+
+    const container = screen.getByRole("alert")
+    expect(container).toHaveAttribute("aria-live", "assertive")
+  })
+})

--- a/__tests__/components/ui/PageHeader.test.tsx
+++ b/__tests__/components/ui/PageHeader.test.tsx
@@ -1,0 +1,39 @@
+import React from "react"
+import { render, screen, within } from "@testing-library/react"
+
+import { Button } from "@/components/ui/button"
+import { PageHeader } from "@/components/ui/page-header"
+
+describe("PageHeader", () => {
+  it("renders heading, description, and breadcrumb navigation", () => {
+    render(
+      <PageHeader
+        title="Team analytics"
+        description="Understand adoption across teams and take action on outliers."
+        breadcrumbs={[
+          { label: "Home", href: "/" },
+          { label: "Analytics", href: "/analytics" },
+          { label: "Team" },
+        ]}
+        actions={<Button>Share</Button>}
+      />
+    )
+
+    const heading = screen.getByRole("heading", { level: 1, name: "Team analytics" })
+    expect(heading).toBeInTheDocument()
+
+    const nav = screen.getByRole("navigation", { name: /breadcrumb/i })
+    const items = within(nav).getAllByRole("listitem")
+    expect(items).toHaveLength(3)
+    expect(items[2]).toHaveAttribute("aria-current", "page")
+
+    expect(screen.getByText("Share")).toBeInTheDocument()
+  })
+
+  it("supports alternate heading levels", () => {
+    render(<PageHeader title="Reports" headingLevel="h2" />)
+
+    const heading = screen.getByRole("heading", { level: 2, name: "Reports" })
+    expect(heading.tagName.toLowerCase()).toBe("h2")
+  })
+})

--- a/__tests__/components/ui/Table.test.tsx
+++ b/__tests__/components/ui/Table.test.tsx
@@ -1,0 +1,55 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { Table, type TableColumn } from "@/components/ui/table"
+
+type Row = {
+  id: string
+  experiment: string
+  conversions: number
+}
+
+const columns: TableColumn<Row>[] = [
+  { id: "experiment", header: "Experiment", sortable: true },
+  { id: "conversions", header: "Conversions", align: "right", sortable: true },
+]
+
+const data: Row[] = [
+  { id: "1", experiment: "Pricing", conversions: 200 },
+  { id: "2", experiment: "Onboarding", conversions: 120 },
+]
+
+describe("Table", () => {
+  it("renders rows and triggers sort events", async () => {
+    const user = userEvent.setup()
+    const handleSort = jest.fn()
+
+    render(
+      <Table<Row>
+        columns={columns}
+        data={data}
+        caption="Experiments table"
+        onSortChange={handleSort}
+      />
+    )
+
+    expect(screen.getByRole("table", { name: /experiments table/i })).toBeInTheDocument()
+    expect(screen.getByText("Pricing")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: /experiment/i }))
+    expect(handleSort).toHaveBeenCalledWith("experiment", "asc")
+  })
+
+  it("shows the default empty state when no data is present", () => {
+    render(
+      <Table<Row>
+        columns={columns}
+        data={[]}
+        caption="Empty table"
+      />
+    )
+
+    expect(screen.getByText(/no data yet/i)).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/ui/Toast.test.tsx
+++ b/__tests__/components/ui/Toast.test.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { Toast } from "@/components/ui/toast"
+
+describe("Toast", () => {
+  it("renders dismissible content and invokes callbacks", async () => {
+    const user = userEvent.setup()
+    const handleClose = jest.fn()
+    const handleAction = jest.fn()
+
+    render(
+      <Toast
+        tone="danger"
+        title="Sync failed"
+        description="Retry or download a backup."
+        action={{ label: "Retry", onClick: handleAction }}
+        onClose={handleClose}
+      />
+    )
+
+    expect(screen.getByRole("alert")).toHaveAttribute("aria-live", "assertive")
+
+    await user.click(screen.getByRole("button", { name: "Retry" }))
+    expect(handleAction).toHaveBeenCalled()
+
+    await user.click(screen.getByRole("button", { name: /dismiss/i }))
+    expect(handleClose).toHaveBeenCalled()
+  })
+})

--- a/components/ui/__stories__/EmptyState.stories.tsx
+++ b/components/ui/__stories__/EmptyState.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { Inbox, ShieldAlert, Sparkles, Star, Upload } from "lucide-react"
+
+import { Button } from "../button"
+import { EmptyState } from "../empty-state"
+
+const meta: Meta<typeof EmptyState> = {
+  title: "Design System/EmptyState",
+  component: EmptyState,
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    title: "No conversations yet",
+    description: "Kick off your next study by inviting candidates or importing interview notes.",
+    icon: <Inbox aria-hidden="true" className="size-6" />,
+    iconAriaLabel: "Empty inbox",
+    tone: "neutral",
+    size: "md",
+    alignment: "center",
+  },
+  argTypes: {
+    tone: {
+      control: "inline-radio",
+      options: ["neutral", "info", "success", "warning", "danger"],
+    },
+    size: {
+      control: "inline-radio",
+      options: ["sm", "md", "lg"],
+    },
+    alignment: {
+      control: "inline-radio",
+      options: ["center", "left"],
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Neutral: Story = {
+  args: {
+    primaryAction: {
+      label: "Invite participants",
+      onClick: () => console.log("invite"),
+    },
+    secondaryAction: {
+      label: "Import CSV",
+      onClick: () => console.log("import"),
+    },
+  },
+}
+
+export const Informational: Story = {
+  args: {
+    tone: "info",
+    icon: <Sparkles aria-hidden="true" className="size-6" />,
+    statusLabel: "Recommendations",
+    title: "Fine-tune your prompts",
+    description:
+      "Review the generative AI checklist to improve reliability before sharing with the team.",
+  },
+}
+
+export const Success: Story = {
+  args: {
+    tone: "success",
+    icon: <Star aria-hidden="true" className="size-6" />,
+    title: "All caught up",
+    description: "Every diagnostic has been reviewed. We'll notify you if something changes.",
+  },
+}
+
+export const Warning: Story = {
+  args: {
+    tone: "warning",
+    icon: <ShieldAlert aria-hidden="true" className="size-6" />,
+    title: "Quota nearly reached",
+    description: "Usage is at 92% of your monthly limit. Upgrade to avoid throttling.",
+    primaryAction: {
+      label: "Upgrade plan",
+      onClick: () => console.log("upgrade"),
+    },
+  },
+}
+
+export const DangerLeftAligned: Story = {
+  args: {
+    tone: "danger",
+    alignment: "left",
+    size: "lg",
+    icon: <Upload aria-hidden="true" className="size-6" />,
+    statusLabel: "Upload failed",
+    title: "We couldn't process your file",
+    description: (
+      <span>
+        Double-check the template and try again. <Button variant="link">Download sample</Button>
+      </span>
+    ),
+  },
+}

--- a/components/ui/__stories__/PageHeader.stories.tsx
+++ b/components/ui/__stories__/PageHeader.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { Button } from "../button"
+import { PageHeader } from "../page-header"
+
+const meta: Meta<typeof PageHeader> = {
+  title: "Design System/PageHeader",
+  component: PageHeader,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    title: "Analytics overview",
+    description: "Monitor how each experiment performs and spot bottlenecks before they grow.",
+  },
+  argTypes: {
+    density: {
+      control: "inline-radio",
+      options: ["comfortable", "compact"],
+    },
+    align: {
+      control: "inline-radio",
+      options: ["left", "between"],
+    },
+    tone: {
+      control: "inline-radio",
+      options: ["default", "muted"],
+    },
+    headingLevel: {
+      control: "inline-radio",
+      options: ["h1", "h2", "h3", "h4", "h5", "h6"],
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithBreadcrumbs: Story = {
+  args: {
+    breadcrumbs: [
+      { label: "Dashboard", href: "#" },
+      { label: "Analytics", href: "#" },
+      { label: "Overview" },
+    ],
+  },
+}
+
+export const WithActions: Story = {
+  args: {
+    align: "between",
+    actions: (
+      <div className="flex flex-wrap items-center gap-2">
+        <Button variant="ghost" tone="neutral">
+          Share
+        </Button>
+        <Button tone="accent">Create report</Button>
+      </div>
+    ),
+  },
+}
+
+export const MutedSurface: Story = {
+  args: {
+    tone: "muted",
+    breadcrumbs: [
+      { label: "Billing", href: "#" },
+      { label: "Plans" },
+    ],
+    actions: (
+      <Button tone="accent">Upgrade plan</Button>
+    ),
+  },
+}
+
+export const CompactDensity: Story = {
+  args: {
+    density: "compact",
+    description: "Use compact density for data-heavy views or layouts with limited vertical space.",
+  },
+}
+
+export const NoDescription: Story = {
+  args: {
+    description: undefined,
+    breadcrumbs: [{ label: "Settings" }],
+  },
+}

--- a/components/ui/__stories__/Table.stories.tsx
+++ b/components/ui/__stories__/Table.stories.tsx
@@ -1,0 +1,217 @@
+import * as React from "react"
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { Sparkles } from "lucide-react"
+
+import { Badge } from "../badge"
+import { Table, type SortDirection, type TableColumn, type TableProps } from "../table"
+import { EmptyState } from "../empty-state"
+
+type ExperimentRow = {
+  id: string
+  experiment: string
+  owner: string
+  status: "Running" | "Paused" | "Draft"
+  conversions: number
+  updated: string
+}
+
+const columns: TableColumn<ExperimentRow>[] = [
+  {
+    id: "experiment",
+    header: "Experiment",
+    accessor: (row) => row.experiment,
+    sortable: true,
+    width: "28%",
+  },
+  {
+    id: "owner",
+    header: "Owner",
+    accessor: (row) => row.owner,
+    sortable: true,
+  },
+  {
+    id: "status",
+    header: "Status",
+    accessor: (row) => {
+      const tone =
+        row.status === "Running"
+          ? "success"
+          : row.status === "Paused"
+          ? "warning"
+          : "default"
+
+      return (
+        <Badge variant="soft" tone={tone} className="font-medium">
+          {row.status}
+        </Badge>
+      )
+    },
+  },
+  {
+    id: "conversions",
+    header: "Conversions",
+    accessor: (row) => row.conversions.toLocaleString(),
+    align: "right",
+    sortable: true,
+  },
+  {
+    id: "updated",
+    header: "Last updated",
+    accessor: (row) => row.updated,
+    sortable: true,
+  },
+]
+
+const data: ExperimentRow[] = [
+  {
+    id: "exp-01",
+    experiment: "Pricing paywall copy",
+    owner: "Leah Griffin",
+    status: "Running",
+    conversions: 1420,
+    updated: "2025-02-14",
+  },
+  {
+    id: "exp-02",
+    experiment: "Onboarding checklist",
+    owner: "Ibrahim Noor",
+    status: "Paused",
+    conversions: 980,
+    updated: "2025-02-11",
+  },
+  {
+    id: "exp-03",
+    experiment: "New hero illustration",
+    owner: "Joana Silva",
+    status: "Draft",
+    conversions: 312,
+    updated: "2025-01-28",
+  },
+  {
+    id: "exp-04",
+    experiment: "Free trial CTA",
+    owner: "Hector Lin",
+    status: "Running",
+    conversions: 1845,
+    updated: "2025-02-03",
+  },
+]
+
+const meta: Meta<typeof Table> = {
+  title: "Design System/Table",
+  component: Table,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    columns: columns as unknown as TableColumn<unknown>[],
+    data,
+    caption: "List of experiments with owner, status, and conversions",
+  },
+  argTypes: {
+    density: {
+      control: "inline-radio",
+      options: ["comfortable", "compact"],
+    },
+    zebra: {
+      control: "boolean",
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+type SortState = { id: string; dir: SortDirection } | undefined
+
+const useSortedData = (rows: ExperimentRow[], sort: SortState) => {
+  return React.useMemo(() => {
+    if (!sort) return rows
+    const key = sort.id as keyof ExperimentRow
+    return [...rows].sort((a, b) => {
+      const aValue = a[key]
+      const bValue = b[key]
+      if (typeof aValue === "number" && typeof bValue === "number") {
+        return sort.dir === "asc" ? aValue - bValue : bValue - aValue
+      }
+      return sort.dir === "asc"
+        ? String(aValue).localeCompare(String(bValue))
+        : String(bValue).localeCompare(String(aValue))
+    })
+  }, [rows, sort])
+}
+
+type ExperimentTableProps = TableProps<ExperimentRow>
+
+const SortingExample: React.FC<ExperimentTableProps> = (props) => {
+  const { data: rows, onSortChange, ...rest } = props
+  const [sort, setSort] = React.useState<SortState>()
+  const sortedRows = useSortedData((rows as ExperimentRow[]) ?? [], sort)
+
+  const handleSortChange = React.useCallback(
+    (columnId: string, direction: SortDirection | null) => {
+      setSort(direction ? { id: columnId, dir: direction } : undefined)
+      onSortChange?.(columnId, direction)
+    },
+    [onSortChange]
+  )
+
+  return (
+    <Table<ExperimentRow>
+      {...rest}
+      data={sortedRows}
+      sort={sort}
+      onSortChange={handleSortChange}
+    />
+  )
+}
+
+export const InteractiveSorting: Story = {
+  render: (args) => (
+    <div className="mx-auto max-w-5xl p-6">
+      <SortingExample {...(args as ExperimentTableProps)} />
+    </div>
+  ),
+}
+
+export const CompactDensity: Story = {
+  render: (args) => (
+    <div className="mx-auto max-w-4xl p-6">
+      <SortingExample
+        {...(args as ExperimentTableProps)}
+        density="compact"
+        zebra
+      />
+    </div>
+  ),
+}
+
+export const Loading: Story = {
+  args: {
+    isLoading: true,
+  },
+}
+
+export const Empty: Story = {
+  args: {
+    data: [],
+  },
+}
+
+export const CustomEmptyState: Story = {
+  args: {
+    data: [],
+    emptyState: (
+      <EmptyState
+        tone="info"
+        icon={<Sparkles aria-hidden="true" className="size-6" />}
+        statusLabel="No experiments yet"
+        title="Start by launching your first test"
+        description="A guided setup will walk you through defining hypotheses and rollout criteria."
+        primaryAction={{ label: "Launch experiment", onClick: () => console.log("launch") }}
+      />
+    ),
+  },
+}

--- a/components/ui/__stories__/Toast.stories.tsx
+++ b/components/ui/__stories__/Toast.stories.tsx
@@ -1,0 +1,128 @@
+import * as React from "react"
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { Button } from "../button"
+import { Toast, type ToastProps, useToastQueue } from "../toast"
+
+const meta: Meta<typeof Toast> = {
+  title: "Design System/Toast",
+  component: Toast,
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    tone: "info",
+    elevation: "sm",
+    dismissible: true,
+    title: "Changes published",
+    description: "Your updates are now live for all reviewers.",
+  },
+  argTypes: {
+    tone: {
+      control: "inline-radio",
+      options: ["info", "success", "warning", "danger"],
+    },
+    elevation: {
+      control: "inline-radio",
+      options: ["none", "sm", "md"],
+    },
+    dismissible: {
+      control: "boolean",
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Info: Story = {
+  args: {
+    action: {
+      label: "View", 
+      onClick: () => console.log("view"),
+    },
+  },
+}
+
+export const Success: Story = {
+  args: {
+    tone: "success",
+    title: "Diagnostics exported",
+    description: "We emailed the report to your analytics inbox.",
+    action: {
+      label: "Undo",
+      onClick: () => console.log("undo"),
+    },
+  },
+}
+
+export const Warning: Story = {
+  args: {
+    tone: "warning",
+    title: "Connection unstable",
+    description: "We'll keep trying in the background and alert you if it fails.",
+  },
+}
+
+export const Danger: Story = {
+  args: {
+    tone: "danger",
+    title: "Sync failed",
+    description: "Retry syncing the library or download a backup.",
+    action: {
+      label: "Retry",
+      onClick: () => console.log("retry"),
+    },
+  },
+}
+
+const QueueDemo = () => {
+  const { toasts, addToast, dismissToast } = useToastQueue()
+
+  const pushToast = (overrides: Partial<ToastProps>) => {
+    addToast({
+      tone: "info",
+      dismissible: true,
+      elevation: "md",
+      title: "Workflow saved",
+      description: "Changes will publish once approved.",
+      ...overrides,
+    })
+  }
+
+  return (
+    <div className="flex w-full max-w-sm flex-col gap-4">
+      <div className="flex flex-wrap gap-2">
+        <Button onClick={() => pushToast({ tone: "success", title: "Segment created", description: "It will appear in targeting shortly." })}>
+          Success toast
+        </Button>
+        <Button variant="outline" onClick={() => pushToast({ tone: "warning", title: "API latency", description: "Traffic is spiking, we are scaling workers." })}>
+          Warning toast
+        </Button>
+        <Button variant="ghost" tone="danger" onClick={() => pushToast({ tone: "danger", title: "Deployment failed", description: "Rollback triggered. Investigate the build logs." })}>
+          Danger toast
+        </Button>
+      </div>
+      <div className="flex flex-col gap-3">
+        {toasts.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border/60 p-6 text-sm text-muted-foreground">
+            Trigger a toast to preview the stack.
+          </div>
+        ) : (
+          toasts.map(({ id, ...toast }) => (
+            <Toast
+              key={id}
+              {...toast}
+              onClose={() => dismissToast(id)}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+export const Queue: Story = {
+  render: () => <QueueDemo />,
+}

--- a/components/ui/__stories__/docs/EmptyState.mdx
+++ b/components/ui/__stories__/docs/EmptyState.mdx
@@ -1,0 +1,55 @@
+import { Controls, Meta, Primary, Props, Stories } from "@storybook/blocks"
+import * as EmptyStateStories from "../EmptyState.stories"
+
+<Meta of={EmptyStateStories} title="Design System/EmptyState/Docs" />
+
+# EmptyState
+
+EmptyState communicates absence, loading, or error scenarios using consistent iconography, copy, and actions.
+
+## When to use
+
+- A collection has no data yet (first-run experience).
+- A filter removes every result and we need to explain next steps.
+- A recoverable error occurs and the user can retry or learn more.
+
+## Usage
+
+```tsx
+import { EmptyState } from "@/components/ui"
+import { Inbox } from "lucide-react"
+
+export function NoSessions() {
+  return (
+    <EmptyState
+      tone="info"
+      icon={<Inbox aria-hidden="true" className="size-6" />}
+      statusLabel="No sessions"
+      title="You're all caught up"
+      description="Start a new diagnostic session or import historic runs to compare trends."
+      primaryAction={{ label: "Start session", onClick: () => console.log("start") }}
+      secondaryAction={{ label: "Import CSV", onClick: () => console.log("import") }}
+    />
+  )
+}
+```
+
+## Component API
+
+<Primary />
+<Controls />
+<Props of={EmptyStateStories.Neutral} />
+
+## Do
+
+- Tailor the headline to be outcome oriented (e.g. "Start your first experiment").
+- Pair status icons with `statusLabel` so color is never the only cue.
+- Keep descriptions short (two sentences max) and actionable.
+
+## Don't
+
+- Use destructive tone for empty results—reserve it for actual failures.
+- Stack more than two call-to-action buttons; link secondary tasks elsewhere.
+- Leave the icon as the only focusable element—actions must be keyboard reachable.
+
+<Stories includePrimary={false} />

--- a/components/ui/__stories__/docs/PageHeader.mdx
+++ b/components/ui/__stories__/docs/PageHeader.mdx
@@ -1,0 +1,65 @@
+import { Controls, Meta, Primary, Props, Stories } from "@storybook/blocks"
+import * as PageHeaderStories from "../PageHeader.stories"
+
+<Meta of={PageHeaderStories} title="Design System/PageHeader/Docs" />
+
+# PageHeader
+
+The PageHeader provides a consistent hero block for authenticated layouts. It aligns breadcrumbs, titles, descriptions, and quick actions so that every view opens with a predictable rhythm.
+
+## When to use
+
+- Introduce a new product surface or dashboard route.
+- Provide contextual breadcrumbs and supporting copy above a dense layout.
+- Pair with tabs or filters that live directly beneath the header.
+
+Avoid using PageHeader for inline sections inside a page—prefer stacked `Card` components instead.
+
+## Usage
+
+```tsx
+import { PageHeader, Button } from "@/components/ui"
+
+export function ExperimentsHeader() {
+  return (
+    <PageHeader
+      tone="muted"
+      align="between"
+      breadcrumbs={[
+        { label: "Dashboard", href: "/app" },
+        { label: "Experiments" },
+      ]}
+      title="Experiment overview"
+      description="Compare how each test is trending and notify collaborators when an action is needed."
+      actions={
+        <div className="flex gap-2">
+          <Button variant="ghost" tone="neutral">
+            Share report
+          </Button>
+          <Button tone="accent">New experiment</Button>
+        </div>
+      }
+    />
+  )
+}
+```
+
+## Component API
+
+<Primary />
+<Controls />
+<Props of={PageHeaderStories.Default} />
+
+## Do
+
+- Keep titles concise—one line is ideal and two lines is the maximum.
+- Use `tone="muted"` when the page background needs subtle separation from the canvas.
+- Switch `density="compact"` when the header sits above tables or forms.
+
+## Don't
+
+- Nest PageHeaders inside cards or modals.
+- Combine more than three breadcrumb levels; collapse intermediate destinations instead.
+- Place destructive actions (like delete) in the primary action slot—prefer menus.
+
+<Stories includePrimary={false} />

--- a/components/ui/__stories__/docs/Table.mdx
+++ b/components/ui/__stories__/docs/Table.mdx
@@ -1,0 +1,65 @@
+import { Controls, Meta, Primary, Props, Stories } from "@storybook/blocks"
+import * as TableStories from "../Table.stories"
+
+<Meta of={TableStories} title="Design System/Table/Docs" />
+
+# Table
+
+Table renders accessible tabular data with sortable headers, zebra striping, and empty/loading states.
+
+## When to use
+
+- Display structured datasets such as experiments, billing history, or feature flags.
+- Allow operators to sort by key metrics like status or conversion rate.
+- Embed contextual empty states when a dataset has no rows.
+
+## Usage
+
+```tsx
+import { Table } from "@/components/ui"
+
+const columns = [
+  { id: "name", header: "Study", sortable: true },
+  { id: "moderator", header: "Moderator" },
+  { id: "status", header: "Status" },
+  { id: "lastRun", header: "Last run", sortable: true },
+]
+
+const data = [
+  { id: "study-1", name: "GenAI onboarding", moderator: "Priya", status: "Running", lastRun: "Mar 12" },
+  { id: "study-2", name: "Pricing survey", moderator: "Noah", status: "Draft", lastRun: "Mar 4" },
+]
+
+export function StudiesTable() {
+  return (
+    <Table
+      columns={columns}
+      data={data}
+      caption="Current usability studies and moderators"
+      onSortChange={(columnId, direction) => {
+        // Update data ordering upstream when the user sorts.
+      }}
+    />
+  )
+}
+```
+
+## Component API
+
+<Primary />
+<Controls />
+<Props of={TableStories.InteractiveSorting} />
+
+## Do
+
+- Provide a `caption` for screen readers even if you hide it visually.
+- Keep numeric columns right-aligned so magnitudes are easy to compare.
+- Use the `emptyState` prop to show recovery guidance when there are zero rows.
+
+## Don't
+
+- Hide critical context in tooltips; keep key values visible.
+- Overload headers with long sentences—use concise nouns or verbs.
+- Enable sorting on columns that render badges or custom JSX without a clear ordering.
+
+<Stories includePrimary={false} />

--- a/components/ui/__stories__/docs/Toast.mdx
+++ b/components/ui/__stories__/docs/Toast.mdx
@@ -1,0 +1,68 @@
+import { Controls, Meta, Primary, Props, Stories } from "@storybook/blocks"
+import * as ToastStories from "../Toast.stories"
+
+<Meta of={ToastStories} title="Design System/Toast/Docs" />
+
+# Toast
+
+Toast surfaces transient notifications without interrupting the current workflow.
+
+## When to use
+
+- Confirm that a background task completed (save, export, sync).
+- Warn users about degraded performance while recovery continues.
+- Offer an undo affordance shortly after an action.
+
+## Usage
+
+```tsx
+import { Toast, useToastQueue } from "@/components/ui"
+
+export function ToastManager() {
+  const { toasts, addToast, dismissToast } = useToastQueue()
+
+  return (
+    <div>
+      <button
+        className="rounded-md bg-primary px-3 py-2 text-primary-foreground"
+        onClick={() =>
+          addToast({
+            tone: "success",
+            title: "Report exported",
+            description: "We emailed the download link to you.",
+            dismissible: true,
+          })
+        }
+      >
+        Trigger toast
+      </button>
+
+      <div className="mt-4 flex flex-col gap-3">
+        {toasts.map(({ id, ...toast }) => (
+          <Toast key={id} {...toast} onClose={() => dismissToast(id)} />
+        ))}
+      </div>
+    </div>
+  )
+}
+```
+
+## Component API
+
+<Primary />
+<Controls />
+<Props of={ToastStories.Info} />
+
+## Do
+
+- Set `tone` based on semantic meaning: `success` for confirmations, `warning` for recoverable risks, `danger` for critical issues.
+- Provide meaningful button labels (e.g. "View report" instead of "OK").
+- Respect reduced motion preferences—the component removes transitions automatically.
+
+## Don't
+
+- Queue more than three toasts at once; collapse or replace older messages instead.
+- Use toast for blocking confirmations—use a modal or inline banner instead.
+- Leave a toast dismissible without also wiring an `onClose` handler.
+
+<Stories includePrimary={false} />

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -1,0 +1,209 @@
+import * as React from "react"
+import { type VariantProps } from "class-variance-authority"
+
+import {
+  emptyStateActions,
+  emptyStateDescription,
+  emptyStateIcon,
+  emptyStateRoot,
+  emptyStateTitle,
+} from "@/lib/design-system/components"
+import { cn } from "@/lib/utils"
+import { Button } from "./button"
+
+type EmptyStateRootVariants = VariantProps<typeof emptyStateRoot>
+
+type EmptyStateTone = NonNullable<EmptyStateRootVariants["tone"]>
+type EmptyStateSize = NonNullable<EmptyStateRootVariants["size"]>
+type EmptyStateAlignment = NonNullable<EmptyStateRootVariants["alignment"]>
+
+type ButtonTone = NonNullable<React.ComponentProps<typeof Button>["tone"]>
+
+export interface EmptyStateAction {
+  label: string
+  onClick?: () => void
+  href?: string
+}
+
+export interface EmptyStateProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    EmptyStateRootVariants {
+  title: string
+  icon?: React.ReactNode
+  iconAriaLabel?: string
+  statusLabel?: string
+  description?: React.ReactNode
+  primaryAction?: EmptyStateAction
+  secondaryAction?: EmptyStateAction
+}
+
+const toneToButtonTone: Record<EmptyStateTone, ButtonTone> = {
+  neutral: "accent",
+  info: "accent",
+  success: "success",
+  warning: "warn",
+  danger: "danger",
+}
+
+const toneLabelMap: Record<EmptyStateTone, string> = {
+  neutral: "Heads up",
+  info: "Informational",
+  success: "Success",
+  warning: "Warning",
+  danger: "Critical",
+}
+
+const toneLabelClassMap: Record<EmptyStateTone, string> = {
+  neutral: "text-muted-foreground",
+  info: "text-info",
+  success: "text-success",
+  warning: "text-warning",
+  danger: "text-destructive",
+}
+
+export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
+  (
+    {
+      icon,
+      iconAriaLabel,
+      statusLabel,
+      title,
+      description,
+      primaryAction,
+      secondaryAction,
+      tone = "neutral",
+      size = "md",
+      alignment = "center",
+      elevated,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    const resolvedTone: EmptyStateTone = tone ?? "neutral"
+    const resolvedSize: EmptyStateSize = size ?? "md"
+    const resolvedAlignment: EmptyStateAlignment = alignment ?? "center"
+
+    const resolvedStatusLabel = statusLabel ?? toneLabelMap[resolvedTone]
+    const role = resolvedTone === "danger" || resolvedTone === "warning" ? "alert" : "status"
+    const ariaLive = role === "alert" ? "assertive" : "polite"
+
+    const descriptionContent = React.useMemo(() => {
+      if (!description) return null
+
+      if (typeof description === "string") {
+        return (
+          <p
+            className={cn(
+              emptyStateDescription({ size: resolvedSize, alignment: resolvedAlignment })
+            )}
+          >
+            {description}
+          </p>
+        )
+      }
+
+      if (React.isValidElement(description)) {
+        const element = description as React.ReactElement<{ className?: string }>
+        return React.cloneElement(element, {
+          className: cn(
+            emptyStateDescription({ size: resolvedSize, alignment: resolvedAlignment }),
+            element.props.className
+          ),
+        })
+      }
+
+      return (
+        <div
+          className={cn(
+            emptyStateDescription({ size: resolvedSize, alignment: resolvedAlignment })
+          )}
+        >
+          {description}
+        </div>
+      )
+    }, [description, resolvedAlignment, resolvedSize])
+
+    const renderAction = (
+      action: EmptyStateAction,
+      variant: "primary" | "secondary"
+    ) => {
+      if (!action) return null
+      const buttonTone = toneToButtonTone[resolvedTone]
+      const variantConfig =
+        variant === "primary"
+          ? { variant: "solid" as const, tone: buttonTone }
+          : { variant: "ghost" as const, tone: "neutral" as ButtonTone }
+
+      if (action.href) {
+        return (
+          <Button asChild variant={variantConfig.variant} tone={variantConfig.tone}>
+            <a href={action.href} onClick={action.onClick}>
+              {action.label}
+            </a>
+          </Button>
+        )
+      }
+
+      return (
+        <Button
+          variant={variantConfig.variant}
+          tone={variantConfig.tone}
+          onClick={action.onClick}
+        >
+          {action.label}
+        </Button>
+      )
+    }
+
+    return (
+      <div
+        ref={ref}
+        role={role}
+        aria-live={ariaLive}
+        className={cn(
+          emptyStateRoot({
+            tone: resolvedTone,
+            size: resolvedSize,
+            alignment: resolvedAlignment,
+            elevated: elevated ? true : undefined,
+          }),
+          className
+        )}
+        {...props}
+      >
+        {icon ? (
+          <span
+            className={cn(emptyStateIcon({ tone: resolvedTone, size: resolvedSize }))}
+            role={iconAriaLabel ? "img" : undefined}
+            aria-label={iconAriaLabel}
+            aria-hidden={iconAriaLabel ? undefined : "true"}
+          >
+            {icon}
+          </span>
+        ) : null}
+
+        <span
+          className={cn(
+            "text-xs font-semibold uppercase tracking-wide",
+            toneLabelClassMap[resolvedTone]
+          )}
+        >
+          {resolvedStatusLabel}
+        </span>
+
+        <h2 className={cn(emptyStateTitle({ size: resolvedSize }))}>{title}</h2>
+        {descriptionContent}
+
+        {(primaryAction || secondaryAction) && (
+          <div className={cn(emptyStateActions({ alignment: resolvedAlignment }))}>
+            {secondaryAction ? renderAction(secondaryAction, "secondary") : null}
+            {primaryAction ? renderAction(primaryAction, "primary") : null}
+          </div>
+        )}
+      </div>
+    )
+  }
+)
+
+EmptyState.displayName = "EmptyState"

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,0 +1,5 @@
+export * from "./button"
+export * from "./page-header"
+export * from "./empty-state"
+export * from "./table"
+export * from "./toast"

--- a/components/ui/page-header.tsx
+++ b/components/ui/page-header.tsx
@@ -1,0 +1,156 @@
+import * as React from "react"
+import { type VariantProps } from "class-variance-authority"
+
+import {
+  pageHeaderActions,
+  pageHeaderBreadcrumbs,
+  pageHeaderDescription,
+  pageHeaderInner,
+  pageHeaderRoot,
+  pageHeaderText,
+  pageHeaderTitle,
+} from "@/lib/design-system/components"
+import { cn } from "@/lib/utils"
+
+export type PageHeaderBreadcrumb = {
+  label: string
+  href?: string
+}
+
+type PageHeaderRootVariants = VariantProps<typeof pageHeaderRoot>
+type PageHeaderInnerVariants = VariantProps<typeof pageHeaderInner>
+
+type HeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
+
+export interface PageHeaderProps
+  extends Omit<React.HTMLAttributes<HTMLElement>, "title">,
+    PageHeaderRootVariants,
+    Pick<PageHeaderInnerVariants, "align"> {
+  title: string | React.ReactNode
+  description?: React.ReactNode
+  breadcrumbs?: PageHeaderBreadcrumb[]
+  actions?: React.ReactNode
+  headingLevel?: HeadingTag
+}
+
+export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
+  (
+    {
+      title,
+      description,
+      breadcrumbs,
+      actions,
+      tone,
+      density,
+      align = "left",
+      headingLevel = "h1",
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    const headingId = React.useId()
+
+    const Heading = headingLevel as React.ElementType
+
+    const descriptionContent = React.useMemo(() => {
+      if (!description) return null
+
+      if (typeof description === "string") {
+        return (
+          <p className={cn(pageHeaderDescription({ density }))}>{description}</p>
+        )
+      }
+
+      if (React.isValidElement(description)) {
+        const element = description as React.ReactElement<{ className?: string }>;
+        return React.cloneElement(element, {
+          className: cn(pageHeaderDescription({ density }), element.props.className),
+        })
+      }
+
+      return (
+        <div className={cn(pageHeaderDescription({ density }))}>{description}</div>
+      )
+    }, [description, density])
+
+    return (
+      <header
+        ref={ref}
+        aria-labelledby={headingId}
+        className={cn(pageHeaderRoot({ tone, density }), className)}
+        data-align={align}
+        {...props}
+      >
+        <div className={cn(pageHeaderInner({ density, align }))}>
+          <div className={cn(pageHeaderText({ density, align }), "w-full")}>
+            {breadcrumbs && breadcrumbs.length > 0 ? (
+              <nav aria-label="Breadcrumb" className="w-full">
+                <ol className={cn(pageHeaderBreadcrumbs({ density }))}>
+                  {breadcrumbs.map((breadcrumb, index) => {
+                    const isLast = index === breadcrumbs.length - 1
+
+                    return (
+                      <li
+                        key={`${breadcrumb.label}-${index}`}
+                        aria-current={isLast ? "page" : undefined}
+                        className="flex items-center gap-2"
+                      >
+                        {breadcrumb.href && !isLast ? (
+                          <a
+                            href={breadcrumb.href}
+                            className="rounded-md px-1 py-0.5 text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                          >
+                            {breadcrumb.label}
+                          </a>
+                        ) : (
+                          <span
+                            className={cn(
+                              "rounded-md px-1 py-0.5",
+                              isLast ? "text-foreground" : "text-muted-foreground"
+                            )}
+                          >
+                            {breadcrumb.label}
+                          </span>
+                        )}
+                        {!isLast ? (
+                          <span aria-hidden="true" className="text-muted-foreground/70">
+                            /
+                          </span>
+                        ) : null}
+                      </li>
+                    )
+                  })}
+                </ol>
+              </nav>
+            ) : null}
+
+            <div className="flex flex-col gap-3">
+              <Heading
+                id={headingId}
+                className={cn(pageHeaderTitle({ density }))}
+              >
+                {title}
+              </Heading>
+              {descriptionContent}
+            </div>
+          </div>
+
+          {actions ? (
+            <div
+              className={cn(
+                pageHeaderActions({ density }),
+                align === "between" ? "md:justify-end" : "md:justify-start",
+                "w-full md:w-auto"
+              )}
+            >
+              {actions}
+            </div>
+          ) : null}
+        </div>
+      </header>
+    )
+  }
+)
+
+PageHeader.displayName = "PageHeader"

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,268 @@
+import * as React from "react"
+import { type VariantProps } from "class-variance-authority"
+import { ArrowUpDown, ChevronDown, ChevronUp } from "lucide-react"
+
+import {
+  tableCell,
+  tableContainer,
+  tableHeaderCell,
+  tableHeaderRow,
+  tableRoot,
+  tableRow,
+} from "@/lib/design-system/components"
+import { cn } from "@/lib/utils"
+import { EmptyState } from "./empty-state"
+
+type TableContainerVariants = VariantProps<typeof tableContainer>
+
+type DensityVariant = NonNullable<TableContainerVariants["density"]>
+
+export type SortDirection = "asc" | "desc"
+
+export interface TableColumn<TData> {
+  id: string
+  header: React.ReactNode
+  accessor?: (row: TData) => React.ReactNode
+  align?: "left" | "center" | "right"
+  width?: string
+  sortable?: boolean
+}
+
+export interface TableProps<TData>
+  extends React.HTMLAttributes<HTMLDivElement>,
+    TableContainerVariants {
+  columns: TableColumn<TData>[]
+  data: TData[]
+  caption?: string
+  captionClassName?: string
+  tableProps?: React.TableHTMLAttributes<HTMLTableElement>
+  isLoading?: boolean
+  emptyState?: React.ReactNode
+  onSortChange?: (columnId: string, direction: SortDirection | null) => void
+  sort?: { id: string; dir: SortDirection }
+  stickyHeader?: boolean
+  getRowId?: (row: TData, index: number) => string
+}
+
+const LoadingIndicator = ({ density }: { density: DensityVariant }) => (
+  <div className="flex items-center justify-center gap-3 text-sm text-muted-foreground">
+    <span
+      aria-hidden="true"
+      className={cn(
+        "size-4 animate-spin rounded-full border-2 border-border/80 border-t-transparent",
+        density === "compact" ? "size-3" : "size-4"
+      )}
+    />
+    <span>Loading</span>
+  </div>
+)
+
+export const Table = <TData,>(
+  {
+    columns,
+    data,
+    caption,
+    captionClassName,
+    tableProps,
+    isLoading,
+    emptyState,
+    onSortChange,
+    sort,
+    density = "comfortable",
+    zebra,
+    stickyHeader,
+    getRowId,
+    className,
+    ...rest
+  }: TableProps<TData>
+) => {
+  const colSpan = Math.max(columns.length, 1)
+  const resolvedDensity: DensityVariant = density ?? "comfortable"
+
+  const renderCellContent = React.useCallback(
+    (row: TData, column: TableColumn<TData>) => {
+      if (column.accessor) {
+        return column.accessor(row)
+      }
+
+      const value = (row as Record<string, unknown>)[column.id]
+      if (React.isValidElement(value)) {
+        return value
+      }
+
+      if (typeof value === "string" || typeof value === "number") {
+        return value
+      }
+
+      if (value === null || value === undefined) {
+        return "—"
+      }
+
+      return String(value)
+    },
+    []
+  )
+
+  const getSortState = (columnId: string): SortDirection | null => {
+    if (!sort || sort.id !== columnId) return null
+    return sort.dir
+  }
+
+  const handleSort = (column: TableColumn<TData>) => {
+    if (!onSortChange || !column.sortable) return
+
+    const current = getSortState(column.id)
+    const next: SortDirection | null = current === "asc" ? "desc" : current === "desc" ? null : "asc"
+    onSortChange(column.id, next)
+  }
+
+  const defaultEmpty = (
+    <EmptyState
+      tone="neutral"
+      alignment="center"
+      size={resolvedDensity === "compact" ? "sm" : "md"}
+      title="No data yet"
+      description="Once data is available it will appear here."
+    />
+  )
+
+  return (
+    <div
+      className={cn(tableContainer({ density: resolvedDensity, zebra }), className)}
+      {...rest}
+    >
+      <div className="relative w-full overflow-x-auto">
+        <table
+          className={cn(tableRoot({ density: resolvedDensity }))}
+          aria-busy={isLoading || undefined}
+          {...tableProps}
+        >
+          {caption ? (
+            <caption className={cn("sr-only", captionClassName)}>{caption}</caption>
+          ) : null}
+          <thead>
+            <tr className={cn(tableHeaderRow({ sticky: stickyHeader ? true : undefined }))}>
+              {columns.map((column) => {
+                const sortState = getSortState(column.id)
+                const isSortable = Boolean(onSortChange && column.sortable)
+                const ariaSort: React.AriaAttributes["aria-sort"] = sortState
+                  ? sortState === "asc"
+                    ? "ascending"
+                    : "descending"
+                  : "none"
+                const textAlignment =
+                  column.align === "right"
+                    ? "text-right"
+                    : column.align === "center"
+                    ? "text-center"
+                    : "text-left"
+                const justifyAlignment =
+                  column.align === "right"
+                    ? "justify-end"
+                    : column.align === "center"
+                    ? "justify-center"
+                    : "justify-between"
+
+                return (
+                  <th
+                    key={column.id}
+                    scope="col"
+                    aria-sort={isSortable ? ariaSort : undefined}
+                    className={cn(
+                      tableHeaderCell({ density: resolvedDensity, align: column.align }),
+                      "align-middle"
+                    )}
+                    style={column.width ? { width: column.width } : undefined}
+                  >
+                    {isSortable ? (
+                      <button
+                        type="button"
+                        onClick={() => handleSort(column)}
+                        className={cn(
+                          "flex w-full items-center gap-2 rounded-md px-1 py-1 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                          textAlignment,
+                          justifyAlignment
+                        )}
+                      >
+                        <span className="truncate">{column.header}</span>
+                        <span className="flex items-center text-muted-foreground" aria-hidden="true">
+                          {sortState === "asc" ? (
+                            <ChevronUp className="size-4" />
+                          ) : sortState === "desc" ? (
+                            <ChevronDown className="size-4" />
+                          ) : (
+                            <ArrowUpDown className="size-4" />
+                          )}
+                        </span>
+                        <span className="sr-only">
+                          {sortState === "asc"
+                            ? "Sort descending"
+                            : sortState === "desc"
+                            ? "Clear sorting"
+                            : "Sort ascending"}
+                        </span>
+                      </button>
+                    ) : (
+                      <span className={cn("block truncate", textAlignment)}>{column.header}</span>
+                    )}
+                  </th>
+                )
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <tr className={cn(tableRow({ density: resolvedDensity }))}>
+                <td
+                  colSpan={colSpan}
+                  className={cn(
+                    tableCell({ density: resolvedDensity, align: "center" }),
+                    "py-10"
+                  )}
+                  aria-live="polite"
+                >
+                  <LoadingIndicator density={resolvedDensity} />
+                </td>
+              </tr>
+            ) : data.length === 0 ? (
+              <tr className={cn(tableRow({ density: resolvedDensity }))}>
+                <td
+                  colSpan={colSpan}
+                  className={cn(
+                    tableCell({ density: resolvedDensity, align: "center" }),
+                    "py-12"
+                  )}
+                >
+                  {emptyState ?? defaultEmpty}
+                </td>
+              </tr>
+            ) : (
+              data.map((row, rowIndex) => {
+                const rowKey = getRowId ? getRowId(row, rowIndex) : `${rowIndex}`
+                return (
+                  <tr key={rowKey} className={cn(tableRow({ density: resolvedDensity }))}>
+                    {columns.map((column) => (
+                      <td
+                        key={`${rowKey}-${column.id}`}
+                        className={cn(
+                          tableCell({ density: resolvedDensity, align: column.align })
+                        )}
+                        style={column.width ? { width: column.width } : undefined}
+                      >
+                        <div className="min-w-0 truncate">
+                          {renderCellContent(row, column)}
+                        </div>
+                      </td>
+                    ))}
+                  </tr>
+                )
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+Table.displayName = "Table"

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -1,0 +1,161 @@
+import * as React from "react"
+import { type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import {
+  toastActions,
+  toastDescription,
+  toastRoot,
+  toastTitle,
+} from "@/lib/design-system/components"
+import { cn } from "@/lib/utils"
+import { Button } from "./button"
+
+type ToastRootVariants = VariantProps<typeof toastRoot>
+
+type ToastTone = NonNullable<ToastRootVariants["tone"]>
+type ToastElevation = NonNullable<ToastRootVariants["elevation"]>
+
+type ButtonTone = NonNullable<React.ComponentProps<typeof Button>["tone"]>
+
+export interface ToastAction {
+  label: string
+  onClick: () => void
+}
+
+export interface ToastProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    ToastRootVariants {
+  title?: string
+  description?: React.ReactNode
+  action?: ToastAction
+  dismissible?: boolean
+  onClose?: () => void
+}
+
+const toneToButtonTone: Record<ToastTone, ButtonTone> = {
+  info: "accent",
+  success: "success",
+  warning: "warn",
+  danger: "danger",
+}
+
+export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
+  (
+    {
+      title,
+      description,
+      action,
+      dismissible = true,
+      onClose,
+      tone = "info",
+      elevation = "sm",
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const resolvedTone: ToastTone = tone ?? "info"
+    const resolvedElevation: ToastElevation = elevation ?? "sm"
+    const isDismissible = dismissible ?? true
+    const role =
+      resolvedTone === "danger" || resolvedTone === "warning" ? "alert" : "status"
+    const ariaLive = role === "alert" ? "assertive" : "polite"
+    const buttonTone = toneToButtonTone[resolvedTone]
+
+    const descriptionContent = React.useMemo(() => {
+      if (!description) return null
+
+      if (typeof description === "string") {
+        return <p className={cn(toastDescription({ tone: resolvedTone }))}>{description}</p>
+      }
+
+      if (React.isValidElement(description)) {
+        const element = description as React.ReactElement<{ className?: string }>
+        return React.cloneElement(element, {
+          className: cn(
+            toastDescription({ tone: resolvedTone }),
+            element.props.className
+          ),
+        })
+      }
+
+      return (
+        <div className={cn(toastDescription({ tone: resolvedTone }))}>{description}</div>
+      )
+    }, [description, resolvedTone])
+
+    return (
+      <div
+        ref={ref}
+        role={role}
+        aria-live={ariaLive}
+        className={cn(
+          toastRoot({
+            tone: resolvedTone,
+            elevation: resolvedElevation,
+            dismissible: isDismissible && onClose ? true : undefined,
+          }),
+          className
+        )}
+        {...props}
+      >
+        {title ? <p className={cn(toastTitle({ tone: resolvedTone }))}>{title}</p> : null}
+        {descriptionContent}
+        {children}
+        {(action || (isDismissible && onClose)) && (
+          <div
+            className={cn(
+              toastActions({ dismissible: isDismissible && onClose ? true : undefined })
+            )}
+          >
+            {action ? (
+              <Button variant="link" tone={buttonTone} onClick={action.onClick} className="px-0">
+                {action.label}
+              </Button>
+            ) : null}
+            {isDismissible && onClose ? (
+              <button
+                type="button"
+                onClick={onClose}
+                className="inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
+                <span className="sr-only">Dismiss notification</span>
+                <X aria-hidden="true" className="size-4" />
+              </button>
+            ) : null}
+          </div>
+        )}
+      </div>
+    )
+  }
+)
+
+Toast.displayName = "Toast"
+
+let toastId = 0
+
+export type ToastQueueItem = ToastProps & { id?: string }
+export type ToastQueueEntry = ToastProps & { id: string }
+
+export const useToastQueue = (initialToasts: ToastQueueItem[] = []) => {
+  const toEntry = React.useCallback((toast: ToastQueueItem): ToastQueueEntry => ({
+    ...toast,
+    id: toast.id ?? `toast-${++toastId}`,
+  }), [])
+
+  const [toasts, setToasts] = React.useState<ToastQueueEntry[]>(() =>
+    initialToasts.map((toast) => toEntry(toast))
+  )
+
+  const addToast = React.useCallback((toast: ToastQueueItem) => {
+    setToasts((previous) => [...previous, toEntry(toast)])
+  }, [toEntry])
+
+  const dismissToast = React.useCallback((id: string) => {
+    setToasts((previous) => previous.filter((toast) => toast.id !== id))
+  }, [])
+
+  return { toasts, addToast, dismissToast }
+}

--- a/lib/design-system/components/empty-state.ts
+++ b/lib/design-system/components/empty-state.ts
@@ -1,0 +1,106 @@
+import { cva } from "class-variance-authority"
+
+export const emptyStateRoot = cva(
+  "flex w-full flex-col rounded-2xl border border-border/60 bg-card text-foreground shadow-sm transition-colors",
+  {
+    variants: {
+      tone: {
+        neutral: "bg-card",
+        info: "border-info/50 bg-info/10", 
+        success: "border-success/50 bg-success/10",
+        warning: "border-warning/60 bg-warning/10",
+        danger: "border-destructive/60 bg-destructive/10",
+      },
+      size: {
+        sm: "gap-4 p-6",
+        md: "gap-5 p-8",
+        lg: "gap-6 p-10",
+      },
+      alignment: {
+        center: "items-center text-center",
+        left: "items-start text-left",
+      },
+      elevated: {
+        true: "shadow-md",
+      },
+    },
+    defaultVariants: {
+      tone: "neutral",
+      size: "md",
+      alignment: "center",
+    },
+  }
+)
+
+export const emptyStateIcon = cva(
+  "flex size-12 items-center justify-center rounded-full border border-border/50 bg-background text-2xl",
+  {
+    variants: {
+      tone: {
+        neutral: "text-muted-foreground",
+        info: "border-info/40 text-info",
+        success: "border-success/40 text-success",
+        warning: "border-warning/50 text-warning",
+        danger: "border-destructive/50 text-destructive",
+      },
+      size: {
+        sm: "size-10 text-lg",
+        md: "size-12 text-xl",
+        lg: "size-14 text-2xl",
+      },
+    },
+    defaultVariants: {
+      tone: "neutral",
+      size: "md",
+    },
+  }
+)
+
+export const emptyStateTitle = cva(
+  "font-semibold text-foreground",
+  {
+    variants: {
+      size: {
+        sm: "text-lg leading-6",
+        md: "text-xl leading-7",
+        lg: "text-2xl leading-8",
+      },
+    },
+    defaultVariants: {
+      size: "md",
+    },
+  }
+)
+
+export const emptyStateDescription = cva(
+  "max-w-xl text-muted-foreground",
+  {
+    variants: {
+      size: {
+        sm: "text-sm leading-6",
+        md: "text-base leading-7",
+        lg: "text-lg leading-8",
+      },
+      alignment: {
+        center: "text-center",
+        left: "text-left",
+      },
+    },
+    defaultVariants: {
+      size: "md",
+      alignment: "center",
+    },
+  }
+)
+
+export const emptyStateActions = cva("flex flex-wrap gap-3", {
+  variants: {
+    alignment: {
+      center: "justify-center",
+      left: "justify-start",
+    },
+  },
+  defaultVariants: {
+    alignment: "center",
+  },
+})

--- a/lib/design-system/components/index.ts
+++ b/lib/design-system/components/index.ts
@@ -1,10 +1,10 @@
 // Design System: Component Style Configurations
 // This file defines reusable component variants and style configurations
 
-import { semantic as colorSemantic, component as colorComponent } from './tokens/colors';
-import { semantic as spacingSemantic, component as spacingComponent } from './tokens/spacing';
-import { component as typographyComponent } from './tokens/typography';
-import { primitive as effectsPrimitive, component as effectsComponent } from './tokens/effects';
+import { semantic as colorSemantic, component as colorComponent } from '../tokens/colors';
+import { semantic as spacingSemantic, component as spacingComponent } from '../tokens/spacing';
+import { component as typographyComponent } from '../tokens/typography';
+import { primitive as effectsPrimitive, component as effectsComponent } from '../tokens/effects';
 
 // BUTTON VARIANTS
 // ---------------------------------------------------------------------------
@@ -399,3 +399,8 @@ export const components = {
 // Legacy compatibility
 export const button = buttonVariants;
 export const card = cardVariants;
+
+export * from "./page-header"
+export * from "./empty-state"
+export * from "./table"
+export * from "./toast"

--- a/lib/design-system/components/page-header.ts
+++ b/lib/design-system/components/page-header.ts
@@ -1,0 +1,112 @@
+import { cva } from "class-variance-authority"
+
+export const pageHeaderRoot = cva(
+  "w-full border-b border-border/60 bg-background text-foreground",
+  {
+    variants: {
+      tone: {
+        default: "bg-background",
+        muted: "bg-muted/60 backdrop-blur-sm",
+      },
+      density: {
+        comfortable: "py-8 md:py-12",
+        compact: "py-4 md:py-6",
+      },
+    },
+    defaultVariants: {
+      tone: "default",
+      density: "comfortable",
+    },
+  }
+)
+
+export const pageHeaderInner = cva("container flex w-full flex-col gap-6", {
+  variants: {
+    align: {
+      left: "items-start",
+      between: "md:flex-row md:items-center md:justify-between",
+    },
+    density: {
+      comfortable: "gap-6",
+      compact: "gap-4",
+    },
+  },
+  defaultVariants: {
+    align: "left",
+    density: "comfortable",
+  },
+})
+
+export const pageHeaderText = cva("flex flex-col gap-4", {
+  variants: {
+    density: {
+      comfortable: "gap-4",
+      compact: "gap-3",
+    },
+    align: {
+      left: "text-left",
+      between: "text-left",
+    },
+  },
+  defaultVariants: {
+    density: "comfortable",
+    align: "left",
+  },
+})
+
+export const pageHeaderTitle = cva(
+  "font-semibold tracking-tight text-foreground",
+  {
+    variants: {
+      density: {
+        comfortable: "text-3xl leading-tight sm:text-4xl",
+        compact: "text-2xl leading-snug sm:text-3xl",
+      },
+    },
+    defaultVariants: {
+      density: "comfortable",
+    },
+  }
+)
+
+export const pageHeaderDescription = cva(
+  "max-w-2xl text-base text-muted-foreground",
+  {
+    variants: {
+      density: {
+        comfortable: "leading-7",
+        compact: "text-sm leading-6",
+      },
+    },
+    defaultVariants: {
+      density: "comfortable",
+    },
+  }
+)
+
+export const pageHeaderBreadcrumbs = cva(
+  "flex flex-wrap items-center gap-2 text-sm text-muted-foreground",
+  {
+    variants: {
+      density: {
+        comfortable: "",
+        compact: "text-xs",
+      },
+    },
+    defaultVariants: {
+      density: "comfortable",
+    },
+  }
+)
+
+export const pageHeaderActions = cva("flex flex-wrap items-center gap-3", {
+  variants: {
+    density: {
+      comfortable: "gap-3",
+      compact: "gap-2",
+    },
+  },
+  defaultVariants: {
+    density: "comfortable",
+  },
+})

--- a/lib/design-system/components/table.ts
+++ b/lib/design-system/components/table.ts
@@ -1,0 +1,93 @@
+import { cva } from "class-variance-authority"
+
+export const tableContainer = cva(
+  "w-full overflow-hidden rounded-xl border border-border/60 bg-card text-foreground shadow-sm",
+  {
+    variants: {
+      density: {
+        comfortable: "",
+        compact: "text-sm",
+      },
+      zebra: {
+        true: "[&>table>tbody>tr:nth-child(even)]:bg-muted/60",
+      },
+    },
+    defaultVariants: {
+      density: "comfortable",
+    },
+  }
+)
+
+export const tableRoot = cva(
+  "min-w-full border-collapse text-left", 
+  {
+    variants: {
+      density: {
+        comfortable: "",
+        compact: "",
+      },
+    },
+    defaultVariants: {
+      density: "comfortable",
+    },
+  }
+)
+
+export const tableHeaderRow = cva("border-b border-border/80 bg-muted/40", {
+  variants: {
+    sticky: {
+      true: "sticky top-0 z-10",
+    },
+  },
+})
+
+export const tableHeaderCell = cva(
+  "whitespace-nowrap text-xs font-semibold uppercase tracking-wide text-muted-foreground",
+  {
+    variants: {
+      align: {
+        left: "text-left",
+        center: "text-center",
+        right: "text-right",
+      },
+      density: {
+        comfortable: "px-4 py-3",
+        compact: "px-3 py-2 text-xs",
+      },
+    },
+    defaultVariants: {
+      align: "left",
+      density: "comfortable",
+    },
+  }
+)
+
+export const tableCell = cva(
+  "border-b border-border/60 text-sm text-foreground align-middle",
+  {
+    variants: {
+      align: {
+        left: "text-left",
+        center: "text-center",
+        right: "text-right",
+      },
+      density: {
+        comfortable: "px-4 py-3",
+        compact: "px-3 py-2 text-sm",
+      },
+    },
+    defaultVariants: {
+      align: "left",
+      density: "comfortable",
+    },
+  }
+)
+
+export const tableRow = cva("transition-colors hover:bg-muted/40", {
+  variants: {
+    density: {
+      comfortable: "",
+      compact: "",
+    },
+  },
+})

--- a/lib/design-system/components/toast.ts
+++ b/lib/design-system/components/toast.ts
@@ -1,0 +1,63 @@
+import { cva } from "class-variance-authority"
+
+export const toastRoot = cva(
+  "pointer-events-auto grid w-full max-w-sm gap-3 rounded-xl border border-border/60 bg-card p-4 text-foreground transition-all duration-200 ease-out focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-background motion-reduce:transition-none",
+  {
+    variants: {
+      tone: {
+        info: "border-info/60 bg-info/10",
+        success: "border-success/60 bg-success/10",
+        warning: "border-warning/60 bg-warning/10",
+        danger: "border-destructive/60 bg-destructive/10",
+      },
+      elevation: {
+        none: "shadow-none",
+        sm: "shadow-sm",
+        md: "shadow-md",
+      },
+      dismissible: {
+        true: "pr-3",
+      },
+    },
+    defaultVariants: {
+      tone: "info",
+      elevation: "sm",
+    },
+  }
+)
+
+export const toastTitle = cva("text-sm font-semibold text-foreground", {
+  variants: {
+    tone: {
+      info: "text-foreground",
+      success: "text-success",
+      warning: "text-warning",
+      danger: "text-destructive",
+    },
+  },
+  defaultVariants: {
+    tone: "info",
+  },
+})
+
+export const toastDescription = cva("text-sm text-muted-foreground", {
+  variants: {
+    tone: {
+      info: "text-muted-foreground",
+      success: "text-success/80",
+      warning: "text-warning/90",
+      danger: "text-destructive/90",
+    },
+  },
+  defaultVariants: {
+    tone: "info",
+  },
+})
+
+export const toastActions = cva("mt-1 flex flex-wrap items-center gap-3", {
+  variants: {
+    dismissible: {
+      true: "justify-between",
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- guard the EmptyState and Toast components against nullable variant props before resolving token-driven styles
- normalize Table density handling and badge tones so token lookups no longer fail type-checking
- update Storybook stories to use meta-aware StoryObj typing and valid badge variants for sample data

## Testing
- npx tsc --noEmit -p tsconfig.build.json
- npm run lint
- npm test -- __tests__/components/ui

------
https://chatgpt.com/codex/tasks/task_e_68d071955260832598901d8b761d21e6