### PR TITLE
feat(ds-migration): codemod features to design-system patterns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN apk add --no-cache \
 
 # Copy package.json and package-lock.json
 COPY package.json package-lock.json ./
+# Ensure scripts needed during npm prepare are available
+COPY scripts/setup-tailwindcss-eslint-shim.js ./scripts/setup-tailwindcss-eslint-shim.js
 
 # Install dependencies
 RUN npm ci

--- a/components/diagnostic/ScoreChart.tsx
+++ b/components/diagnostic/ScoreChart.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 interface ScoreChartProps {
@@ -9,18 +10,18 @@ interface ScoreChartProps {
   showStatus?: boolean;
 }
 
-type ScoreTone = "success" | "warning" | "error";
+type ScoreTone = "success" | "warning" | "danger";
 
 const toneClassMap: Record<ScoreTone, string> = {
   success: "text-success",
   warning: "text-warning",
-  error: "text-error",
+  danger: "text-error",
 };
 
 function getScoreTone(score: number): ScoreTone {
   if (score >= 70) return "success";
   if (score >= 50) return "warning";
-  return "error";
+  return "danger";
 }
 
 function getScoreStatus(score: number): string {
@@ -127,13 +128,13 @@ export const ScoreChart: React.FC<ScoreChartProps> = ({
           </span>
         </div>
       </div>
-      {showStatus && (
-        <div className="text-center mt-2">
-          <span className={cn("text-sm font-medium", toneClass)}>
+      {showStatus ? (
+        <div className="mt-3 flex justify-center">
+          <Badge tone={tone} variant="soft" size="sm">
             {getScoreStatus(displayScore)}
-          </span>
+          </Badge>
         </div>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/components/marketing/sections/enhanced-social-proof.tsx
+++ b/components/marketing/sections/enhanced-social-proof.tsx
@@ -125,19 +125,16 @@ const socialProofBadges: SocialProofBadge[] = [
 const SocialProofCard = ({ badge }: { badge: SocialProofBadge }) => {
   return (
     <motion.div
-      className="flex-shrink-0 mx-2 min-w-[200px]"
-      whileHover={{ 
-        y: -4, 
+      className="mx-2 w-56 flex-shrink-0"
+      whileHover={{
+        y: -4,
         scale: 1.02,
         transition: { duration: 0.2 }
       }}
       initial={{ opacity: 0.8 }}
       whileInView={{ opacity: 1 }}
     >
-      <Card
-        size="sm"
-        className="hover:shadow-lg transition-all duration-200 bg-card text-card-foreground border border-border/60"
-      >
+      <Card size="sm" className="border border-border/60 bg-card text-card-foreground transition-all duration-200 hover:shadow-lg">
         <div className="flex flex-col gap-3">
           <Badge
             size="sm"
@@ -167,7 +164,7 @@ export function EnhancedSocialProof() {
         initial={{ opacity: 0, y: 20 }}
         animate={inView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
         transition={{ duration: 0.6 }}
-        className="text-xl sm:text-2xl md:text-3xl font-semibold text-center mb-12 text-secondary"
+        className="mb-12 text-balance text-center text-3xl font-semibold tracking-tight text-foreground sm:text-4xl"
       >
         Trusted by Hundreds of Cloud Professionals Worldwide
       </motion.h2>

--- a/components/patterns/Container.tsx
+++ b/components/patterns/Container.tsx
@@ -20,8 +20,11 @@ type PolymorphicProps<T extends keyof JSX.IntrinsicElements> = {
   children?: React.ReactNode
 } & Omit<JSX.IntrinsicElements[T], "className" | "children">
 
+export type ContainerProps<T extends keyof JSX.IntrinsicElements = "div"> =
+  PolymorphicProps<T>
+
 export function Container<T extends keyof JSX.IntrinsicElements = "div">(
-  props: PolymorphicProps<T>,
+  props: ContainerProps<T>,
 ) {
   const { as, size = "xl", className, children, ...rest } = props
   const Comp = (as ?? "div") as React.ElementType

--- a/components/patterns/container.stories.tsx
+++ b/components/patterns/container.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { Container, type ContainerProps } from "./Container"
+
+const meta: Meta<typeof Container> = {
+  title: "Patterns/Container",
+  component: Container,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Tokenised width wrapper that centers content and applies responsive horizontal padding consistent with the design system.",
+      },
+    },
+  },
+  argTypes: {
+    as: { control: false },
+    className: { control: false },
+    children: { control: false },
+    size: {
+      control: { type: "inline-radio" },
+      options: ["sm", "md", "lg", "xl", "2xl", "full"],
+    },
+  },
+  args: {
+    size: "xl",
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const Placeholder = ({ label }: { label: string }) => (
+  <div className="rounded-lg border border-dashed border-border bg-muted/40 p-6 text-sm text-muted-foreground">
+    {label}
+  </div>
+)
+
+export const Playground: Story = {
+  render: (args: ContainerProps) => (
+    <div className="space-y-6 bg-surface/60 py-10">
+      <Container {...args}>
+        <Placeholder label={`Container size: ${args.size ?? "xl"}`} />
+      </Container>
+    </div>
+  ),
+}
+
+export const CustomElement: Story = {
+  args: {
+    as: "section",
+    size: "lg",
+  },
+  render: (args: ContainerProps<"section">) => (
+    <div className="space-y-6 bg-surface/60 py-10">
+      <Container {...args}>
+        <Placeholder label="Rendered as a semantic <section> element" />
+      </Container>
+    </div>
+  ),
+}

--- a/components/patterns/section.stories.tsx
+++ b/components/patterns/section.stories.tsx
@@ -79,12 +79,12 @@ export const FullBleed: Story = {
   },
   render: (args) => (
     <Section {...args} className="overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-br from-blue-600 via-blue-700 to-cyan-600 opacity-90" />
+      <div className="absolute inset-0 bg-gradient-to-br from-accent via-info to-info/90 opacity-90" />
       <div className="relative">
         <div className="py-section_lg">
-          <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 text-center text-white">
+          <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 text-center text-accent-foreground">
             <h2 className="text-4xl font-bold tracking-tight">Full-bleed hero</h2>
-            <p className="mt-4 text-lg text-blue-100">
+            <p className="mt-4 text-lg text-foreground/90">
               Combine the Section primitive with your own layout primitives for wide experiences while preserving rhythm and
               divider tokens.
             </p>

--- a/components/pricing/PricingCard.stories.tsx
+++ b/components/pricing/PricingCard.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { PricingCard } from "./PricingCard"
+
+const baseTier = {
+  id: "starter",
+  name: "Starter",
+  description: "Essentials for individual learners preparing for Testero exams.",
+  monthlyPrice: 29,
+  annualPrice: 290,
+  monthlyPriceId: "price_monthly",
+  annualPriceId: "price_annual",
+  aiCredits: 200,
+  features: [
+    "Adaptive practice exams",
+    "Weekly study plan",
+    "Email reminders",
+  ],
+  highlighted: ["Exam-day readiness checklist"],
+  recommended: false,
+  savingsPercentage: 20,
+}
+
+const recommendedTier = {
+  ...baseTier,
+  id: "pro",
+  name: "Pro",
+  monthlyPrice: 59,
+  annualPrice: 590,
+  aiCredits: 500,
+  highlighted: ["1:1 readiness review", "Priority question support"],
+  features: [...baseTier.features, "Live cohort workshops"],
+  recommended: true,
+  savingsPercentage: 25,
+}
+
+const meta: Meta<typeof PricingCard> = {
+  title: "Pricing/PricingCard",
+  component: PricingCard,
+  args: {
+    billingInterval: "monthly",
+    loading: false,
+    loadingId: null,
+    onCheckout: (priceId: string, tierName: string) => {
+      console.log(`Checkout → ${tierName} (${priceId})`)
+    },
+  },
+  argTypes: {
+    billingInterval: {
+      control: { type: "inline-radio" },
+      options: ["monthly", "annual"],
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Monthly: Story = {
+  args: {
+    tier: baseTier,
+  },
+}
+
+export const AnnualRecommended: Story = {
+  args: {
+    tier: recommendedTier,
+    billingInterval: "annual",
+  },
+}

--- a/components/pricing/PricingCard.tsx
+++ b/components/pricing/PricingCard.tsx
@@ -2,6 +2,17 @@
 
 import React from "react";
 import { CheckCircle, Sparkles, TrendingUp } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 interface PricingCardProps {
@@ -38,126 +49,107 @@ export function PricingCard({
   const monthlyEquivalent = billingInterval === "annual" ? Math.round(tier.annualPrice / 12) : null;
 
   return (
-    <div
+    <Card
       data-recommended={tier.recommended ? "true" : undefined}
+      variant={tier.recommended ? "elevated" : "default"}
+      size="lg"
       className={cn(
-        "relative box-border w-full max-w-full rounded-2xl border-2 bg-white p-8 shadow-lg transition-all duration-200",
-        "motion-reduce:transition-none motion-reduce:transform-none",
+        "relative w-full",
         tier.recommended
-          ? "border-blue-500 bg-gradient-to-b from-blue-50 via-white to-white pt-12 ring-2 ring-blue-500/20 shadow-xl md:shadow-2xl md:hover:shadow-2xl md:motion-safe:scale-105"
-          : "border-gray-200 md:hover:border-gray-300 md:hover:shadow-xl",
-        billingInterval === "annual" && tier.savingsPercentage ? "pt-12" : null
+          ? "border-accent/50 ring-2 ring-accent/25"
+          : "border-border/60",
+        billingInterval === "annual" && tier.savingsPercentage ? "pt-6" : ""
       )}
     >
-      {/* Recommended Badge */}
-      {tier.recommended && (
-        <div className="absolute left-1/2 top-6 -translate-x-1/2">
-          <div className="flex items-center gap-1 rounded-full bg-gradient-to-r from-blue-600 to-cyan-600 px-4 py-1.5 text-sm font-semibold text-white shadow-lg">
-            <Sparkles className="h-4 w-4" />
-            MOST POPULAR
-          </div>
+      {tier.recommended ? (
+        <div className="absolute inset-x-0 -top-4 flex justify-center">
+          <Badge
+            tone="accent"
+            variant="solid"
+            icon={<Sparkles className="h-4 w-4" aria-hidden="true" />}
+            className="shadow-lg"
+          >
+            Most popular
+          </Badge>
         </div>
-      )}
+      ) : null}
 
-      {/* Savings Badge */}
-      {billingInterval === "annual" && tier.savingsPercentage && (
+      {billingInterval === "annual" && tier.savingsPercentage ? (
         <div className="absolute right-6 top-6">
-          <div className="rounded-full bg-green-500 px-3 py-1 text-xs font-bold text-white shadow-md">
-            SAVE {tier.savingsPercentage}%
+          <Badge tone="success" variant="solid" size="sm" className="shadow-sm">
+            Save {tier.savingsPercentage}%
+          </Badge>
+        </div>
+      ) : null}
+
+      <CardHeader className="gap-2">
+        <CardTitle className="text-3xl font-semibold text-foreground">
+          {tier.name}
+        </CardTitle>
+        <CardDescription>{tier.description}</CardDescription>
+      </CardHeader>
+
+      <CardContent className="gap-6">
+        <div className="space-y-3">
+          <div className="flex items-baseline gap-2">
+            <span className="text-5xl font-semibold tracking-tight text-foreground">
+              ${price}
+            </span>
+            <span className="text-lg text-muted-foreground">
+              /{billingInterval === "monthly" ? "month" : "year"}
+            </span>
+          </div>
+          {monthlyEquivalent ? (
+            <p className="text-sm text-muted-foreground">
+              That&apos;s only ${monthlyEquivalent}/month
+            </p>
+          ) : null}
+          <div className="flex items-center gap-2 text-sm font-medium text-accent">
+            <TrendingUp className="h-4 w-4" aria-hidden="true" />
+            {tier.aiCredits} AI credits included monthly
           </div>
         </div>
-      )}
 
-      {/* Card Header */}
-      <div className="mb-6">
-        <h3 className="text-2xl font-bold text-gray-900">{tier.name}</h3>
-        <p className="mt-2 text-sm text-gray-600">{tier.description}</p>
-      </div>
+        {tier.highlighted && tier.highlighted.length > 0 ? (
+          <div className="space-y-2 rounded-lg border border-accent/30 bg-accent/5 p-4">
+            {tier.highlighted.map((feature) => (
+              <div key={feature} className="flex items-center gap-2">
+                <CheckCircle className="h-5 w-5 flex-shrink-0 text-accent" aria-hidden="true" />
+                <span className="text-sm font-medium text-foreground">{feature}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
 
-      {/* Pricing */}
-      <div className="mb-6">
-        <div className="flex items-baseline">
-          <span className="text-5xl font-bold tracking-tight text-gray-900">${price}</span>
-          <span className="ml-2 text-lg text-gray-500">
-            /{billingInterval === "monthly" ? "month" : "year"}
-          </span>
-        </div>
-        {monthlyEquivalent && (
-          <p className="mt-1 text-sm text-gray-600">That&apos;s only ${monthlyEquivalent}/month</p>
-        )}
-        <div className="mt-3 flex items-center gap-2 text-sm font-medium text-blue-600">
-          <TrendingUp className="h-4 w-4" />
-          {tier.aiCredits} AI credits included monthly
-        </div>
-      </div>
-
-      {/* Highlighted Features */}
-      {tier.highlighted && tier.highlighted.length > 0 && (
-        <div className="mb-4 space-y-2 rounded-lg bg-blue-50 p-4">
-          {tier.highlighted.map((feature) => (
-            <div key={feature} className="flex items-center gap-2">
-              <CheckCircle className="h-5 w-5 flex-shrink-0 text-blue-600" />
-              <span className="text-sm font-medium text-gray-900">{feature}</span>
-            </div>
+        <ul className="space-y-3">
+          {tier.features.map((feature) => (
+            <li key={feature} className="flex items-start gap-3 text-sm text-muted-foreground">
+              <CheckCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-success" aria-hidden="true" />
+              <span>{feature}</span>
+            </li>
           ))}
-        </div>
-      )}
+        </ul>
+      </CardContent>
 
-      {/* All Features */}
-      <ul className="mb-8 space-y-3">
-        {tier.features.map((feature) => (
-          <li key={feature} className="flex items-start gap-3">
-            <CheckCircle className="h-5 w-5 flex-shrink-0 text-green-500 mt-0.5" />
-            <span className="text-sm text-gray-600">{feature}</span>
-          </li>
-        ))}
-      </ul>
+      <CardFooter className="flex-col items-stretch gap-3 border-0 pt-0">
+        <Button
+          fullWidth
+          tone={tier.recommended ? "accent" : "neutral"}
+          variant="solid"
+          size="lg"
+          loading={isLoading}
+          disabled={!priceId}
+          onClick={() => priceId && onCheckout(priceId, tier.name)}
+        >
+          Get started
+        </Button>
 
-      {/* CTA Button */}
-      <button
-        onClick={() => priceId && onCheckout(priceId, tier.name)}
-        disabled={isLoading || !priceId}
-        className={cn(
-          "w-full rounded-lg px-6 py-3 text-center font-semibold transition-all duration-200",
-          "disabled:cursor-not-allowed disabled:opacity-50",
-          tier.recommended
-            ? "bg-gradient-to-r from-blue-600 to-cyan-600 text-white hover:from-blue-700 hover:to-cyan-700 shadow-md hover:shadow-lg"
-            : "bg-gray-900 text-white hover:bg-gray-800"
-        )}
-      >
-        {isLoading ? (
-          <span className="flex items-center justify-center">
-            <svg
-              className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-            >
-              <circle
-                className="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                strokeWidth="4"
-              />
-              <path
-                className="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-              />
-            </svg>
-            Processing...
-          </span>
-        ) : (
-          "Get Started"
-        )}
-      </button>
-
-      {/* Trust indicator */}
-      {tier.recommended && (
-        <p className="mt-4 text-center text-xs text-gray-500">Chosen by 73% of our users</p>
-      )}
-    </div>
+        {tier.recommended ? (
+          <p className="text-center text-xs text-muted-foreground">
+            Chosen by 73% of our users
+          </p>
+        ) : null}
+      </CardFooter>
+    </Card>
   );
 }

--- a/components/sections/TrustedBySection.tsx
+++ b/components/sections/TrustedBySection.tsx
@@ -2,41 +2,13 @@
 
 import React from "react";
 import Image from "next/image";
-import { cn } from "@/lib/utils";
+
 import { Marquee } from "@/components/marketing/effects/marquee";
 import { Section } from "@/components/patterns";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
 import { partners, type Partner } from "@/data/partners";
-
-// Component-specific design tokens following the design system
-const designTokens = {
-  colors: {
-    // Using design system color tokens
-    text: {
-      primary: "text-slate-800 dark:text-white",
-      secondary: "text-slate-600 dark:text-slate-400",
-      muted: "text-slate-400 dark:text-slate-600",
-    },
-    logo: {
-      container: "bg-slate-50 dark:bg-slate-800/50",
-      border: "border-slate-200 dark:border-slate-700",
-    },
-  },
-  typography: {
-    // Using design system typography tokens
-    sectionTitle: "text-2xl sm:text-3xl md:text-4xl font-semibold",
-    subtitle: "text-base md:text-lg",
-    logoTitle: "text-sm font-semibold",
-  },
-  spacing: {
-    logo: "h-12 md:h-16",
-    logoContainer: "h-20 md:h-24",
-  },
-  effects: {
-    logoHover: "hover:scale-105 transition-all duration-300",
-    logoFilter: "grayscale hover:grayscale-0 opacity-70 hover:opacity-100",
-    gradientMask: "bg-gradient-to-r from-white via-transparent to-white dark:from-slate-950 dark:via-transparent dark:to-slate-950",
-  },
-};
+import { cn } from "@/lib/utils";
 
 interface LogoCardProps {
   partner: Partner;
@@ -51,44 +23,36 @@ function LogoCard({ partner, className }: LogoCardProps) {
   };
 
   return (
-    <div
+    <Card
+      aria-label={`Visit ${partner.name} website`}
       className={cn(
-        // Base container styles
-        "flex items-center justify-center p-4 rounded-lg border cursor-pointer",
-        // Design system colors
-        designTokens.colors.logo.container,
-        designTokens.colors.logo.border,
-        // Effects
-        designTokens.effects.logoHover,
+        "group relative flex h-20 w-40 cursor-pointer items-center justify-center overflow-hidden",
+        "bg-surface-muted/70 text-muted-foreground transition-transform duration-200 hover:-translate-y-0.5 hover:bg-surface-elevated",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "dark:bg-surface-muted/50",
         className
       )}
+      compact
+      allowInternalSpacingOverride
       onClick={handleClick}
-      role="button"
-      tabIndex={0}
-      aria-label={`Visit ${partner.name} website`}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
           handleClick();
         }
       }}
+      role="button"
+      tabIndex={0}
     >
-      <div className="relative w-full h-full flex items-center justify-center">
-        <Image
-          src={partner.logo}
-          alt={partner.logoAlt}
-          width={120}
-          height={48}
-          className={cn(
-            "object-contain transition-all duration-300",
-            designTokens.spacing.logo,
-            designTokens.effects.logoFilter
-          )}
-          priority={false}
-          loading="lazy"
-        />
-      </div>
-    </div>
+      <Image
+        src={partner.logo}
+        alt={partner.logoAlt}
+        width={120}
+        height={48}
+        loading="lazy"
+        className="h-12 w-auto object-contain opacity-80 transition duration-300 ease-out grayscale group-hover:opacity-100 group-hover:grayscale-0"
+      />
+    </Card>
   );
 }
 
@@ -131,99 +95,60 @@ export function TrustedBySection({
       surface="default"
       className={className}
     >
-        {/* Header */}
-        <div className="text-center mb-8 md:mb-12">
-          <h2
-            className={cn(
-              designTokens.typography.sectionTitle,
-              designTokens.colors.text.primary
-            )}
-          >
+      <div className="flex flex-col gap-10">
+        <div className="flex flex-col items-center text-center gap-4">
+          <Badge tone="accent" variant="soft" size={isCompact ? "sm" : "md"} className="w-fit">
+            Trusted by teams
+          </Badge>
+          <h2 className="text-balance text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
             {title}
           </h2>
-          {subtitle && (
-            <p
-              className={cn(
-                designTokens.typography.subtitle,
-                designTokens.colors.text.secondary,
-                "mt-4"
-              )}
-            >
+          {subtitle ? (
+            <p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
               {subtitle}
             </p>
-          )}
+          ) : null}
         </div>
 
-        {/* Logo Carousel */}
         <div className="relative">
-          {/* Gradient masks for fade effect */}
-          {showGradientMask && (
+          {showGradientMask ? (
             <>
-              <div className="absolute left-0 top-0 bottom-0 w-20 z-10 pointer-events-none">
-                <div className={cn(
-                  "w-full h-full",
-                  designTokens.effects.gradientMask
-                )} />
+              <div className="pointer-events-none absolute inset-y-0 left-0 w-24">
+                <div className="h-full w-full bg-gradient-to-r from-background via-transparent to-background" />
               </div>
-              <div className="absolute right-0 top-0 bottom-0 w-20 z-10 pointer-events-none">
-                <div className={cn(
-                  "w-full h-full rotate-180",
-                  designTokens.effects.gradientMask
-                )} />
+              <div className="pointer-events-none absolute inset-y-0 right-0 w-24">
+                <div className="h-full w-full rotate-180 bg-gradient-to-r from-background via-transparent to-background" />
               </div>
             </>
-          )}
+          ) : null}
 
-          {/* Marquee Container */}
-          <div 
-            className={cn(
-              "overflow-hidden w-full",
-              designTokens.spacing.logoContainer
-            )}
+          <div
+            className="relative h-24 w-full overflow-hidden"
             aria-live="polite"
             aria-label="Partner logos carousel"
           >
             {prefersReducedMotion ? (
-              // Static grid for reduced motion
-              <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4 items-center">
+              <div className="grid h-full grid-cols-2 items-center gap-4 sm:grid-cols-4 lg:grid-cols-6">
                 {partnerList.slice(0, 8).map((partner) => (
-                  <LogoCard
-                    key={partner.id}
-                    partner={partner}
-                    className="w-full"
-                  />
+                  <LogoCard key={partner.id} partner={partner} className="h-full w-full" />
                 ))}
               </div>
             ) : (
-              // Animated marquee
-              <Marquee
-                speed={marqueeSpeed}
-                pauseOnHover={pauseOnHover}
-                reverse={direction === "right"}
-              >
+              <Marquee speed={marqueeSpeed} pauseOnHover={pauseOnHover} reverse={direction === "right"}>
                 {partnerList.map((partner) => (
-                  <LogoCard
-                    key={partner.id}
-                    partner={partner}
-                    className="w-36 md:w-44 flex-shrink-0 mx-2"
-                  />
+                  <LogoCard key={partner.id} partner={partner} className="mx-3 flex-shrink-0" />
                 ))}
               </Marquee>
             )}
           </div>
         </div>
 
-        {/* Optional CTA */}
-        {!isCompact && (
-          <div className="text-center mt-8 md:mt-12">
-            <p className={cn(
-              "text-sm",
-              designTokens.colors.text.muted
-            )}>
-              Join 100+ companies that trust our platform
-            </p>
-          </div>
-        )}
+        {!isCompact ? (
+          <p className="text-center text-sm text-muted-foreground">
+            Join 100+ companies that trust our platform
+          </p>
+        ) : null}
+      </div>
     </Section>
   );
 }

--- a/components/ui/__stories__/Badge.stories.tsx
+++ b/components/ui/__stories__/Badge.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { Badge, type BadgeProps } from "../badge"
+
+const meta: Meta<typeof Badge> = {
+  title: "UI/Badge",
+  component: Badge,
+  args: {
+    children: "Badge label",
+    variant: "soft",
+    tone: "accent",
+    size: "md",
+  },
+  argTypes: {
+    variant: {
+      control: { type: "inline-radio" },
+      options: ["solid", "soft", "outline", "ghost"],
+    },
+    tone: {
+      control: { type: "select" },
+      options: ["default", "accent", "success", "warning", "danger", "neutral", "info"],
+    },
+    size: {
+      control: { type: "inline-radio" },
+      options: ["sm", "md"],
+    },
+    icon: { control: false },
+    asChild: { control: { type: "boolean" } },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Semantic badge primitive that maps tone + variant props to design tokens. Supports icon slots and ghost/outline styles for marketing use cases.",
+      },
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Playground: Story = {}
+
+const tones: BadgeProps["tone"][] = [
+  "default",
+  "accent",
+  "success",
+  "warning",
+  "danger",
+  "neutral",
+  "info",
+]
+
+export const ToneMatrix: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap gap-3">
+      {tones.map((tone) => (
+        <Badge key={tone} {...args} tone={tone}>
+          {tone}
+        </Badge>
+      ))}
+    </div>
+  ),
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -20,6 +20,8 @@ const badgeVariants = cva(
         success: "text-success",
         warning: "text-warning",
         danger: "text-error",
+        neutral: "text-muted-foreground",
+        info: "text-info",
       },
       size: {
         sm: "h-6 px-2 text-xs gap-1",
@@ -53,6 +55,16 @@ const badgeVariants = cva(
         class: "bg-error text-background",
       },
       {
+        variant: "solid",
+        tone: "neutral",
+        class: "bg-muted text-foreground",
+      },
+      {
+        variant: "solid",
+        tone: "info",
+        class: "bg-info text-background",
+      },
+      {
         variant: "soft",
         tone: "default",
         class: "bg-muted text-foreground ring-border/60",
@@ -76,6 +88,16 @@ const badgeVariants = cva(
         variant: "soft",
         tone: "danger",
         class: "bg-error/10 text-error ring-error/20",
+      },
+      {
+        variant: "soft",
+        tone: "neutral",
+        class: "bg-muted/70 text-muted-foreground ring-border/40",
+      },
+      {
+        variant: "soft",
+        tone: "info",
+        class: "bg-info/10 text-info ring-info/20",
       },
       {
         variant: "outline",
@@ -103,6 +125,16 @@ const badgeVariants = cva(
         class: "text-error ring-error/40",
       },
       {
+        variant: "outline",
+        tone: "neutral",
+        class: "text-muted-foreground ring-border/50",
+      },
+      {
+        variant: "outline",
+        tone: "info",
+        class: "text-info ring-info/35",
+      },
+      {
         variant: "ghost",
         tone: "default",
         class: "hover:bg-muted/70",
@@ -126,6 +158,16 @@ const badgeVariants = cva(
         variant: "ghost",
         tone: "danger",
         class: "text-error hover:bg-error/10",
+      },
+      {
+        variant: "ghost",
+        tone: "neutral",
+        class: "text-muted-foreground hover:bg-muted/60",
+      },
+      {
+        variant: "ghost",
+        tone: "info",
+        class: "text-info hover:bg-info/10",
       },
     ],
     defaultVariants: {

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -116,7 +116,7 @@ const horizontalInsetSpacing: Record<CardSize, { negative: string; padding: stri
 
 const disallowedSpacingPattern = /\b(p[trblxy]?|px|py|gap|space-[xy])(-|\[)/
 
-type CardProps = React.ComponentPropsWithoutRef<"div"> &
+export type CardProps = React.ComponentPropsWithoutRef<"div"> &
   VariantProps<typeof cardVariants> & {
     allowInternalSpacingOverride?: boolean
   }

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,4 +1,6 @@
 export * from "./button"
+export * from "./badge"
+export * from "./card"
 export * from "./page-header"
 export * from "./empty-state"
 export * from "./table"

--- a/docs/ds-migration-report.md
+++ b/docs/ds-migration-report.md
@@ -1,0 +1,105 @@
+# Design System Migration Report
+
+_Last updated: 2025-09-22 00:49 UTC_
+
+## Summary
+- Introduced codemod toolchain for removing local design token objects, normalising containers/sections, upgrading buttons, swapping badges, and flagging raw hex usage.
+- Migrated marketing and pricing surfaces to consume `<Section>`, `<Container>`, `<Card>`, `<Button>`, and `<Badge>` primitives from the central design system.
+- Added Storybook coverage for Container, Badge, and PricingCard to document new variant APIs, plus CLI/ESLint guardrails that block ad-hoc gradients and arbitrary Tailwind values.
+
+## Migrated Modules
+| Module | Key Patterns Adopted | Notes |
+| --- | --- | --- |
+| `components/sections/TrustedBySection.tsx` | `<Section>`, `<Badge tone="accent">`, `<Card compact>` | Removed bespoke `designTokens` map and gradient masks now use semantic background tokens. |
+| `components/pricing/PricingCard.tsx` | `<Card variant="elevated">`, `<Button tone="accent">`, `<Badge tone>` | CTA now leverages DS button spinner/variants, highlight list reuses semantic success/accent tokens. |
+| `components/marketing/sections/enhanced-social-proof.tsx` | `<Section size="lg">`, `<Badge variant="soft">`, `<Card size="sm">` | Replaced arbitrary width tokens and deprecated text utilities with DS typography colours. |
+| `components/diagnostic/ScoreChart.tsx` | `<Badge tone>` | Score status chips now rely on DS badge variants while keeping SVG rendering intact. |
+
+## Codemod & Guardrail Tooling
+- `scripts/codemods/ds/run-all.ts` orchestrates:
+  - `remove-local-designTokens.ts`
+  - `wrap-with-container-section.ts`
+  - `button-to-ds-variants.ts`
+  - `badge-and-status.ts`
+  - `hex-to-semantic.ts`
+- Added npm scripts `codemod:ds:dry`, `codemod:ds:run`, and `lint:design`.
+- `scripts/guards/design-lints.js` blocks raw hex values and Tailwind arbitrary values across app, components, and lib directories.
+- `lint-staged` + `simple-git-hooks` enforce pre-commit design linting.
+- ESLint now loads the Tailwind v4-compatible `eslint-plugin-tailwindcss@4.0.0-beta.0` and errors on `tailwindcss/no-arbitrary-value`.
+
+## Before & After Highlights
+### TrustedBySection
+```diff
+-const designTokens = { /* bespoke colours, spacing, effects */ }
+-<div className="text-center mb-8 md:mb-12">
+-  <h2 className={cn(designTokens.typography.sectionTitle, designTokens.colors.text.primary)}>
+-    {title}
+-  </h2>
+-</div>
++<Badge tone="accent" variant="soft" className="w-fit">Trusted by teams</Badge>
++<h2 className="text-balance text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
++  {title}
++</h2>
++<LogoCard ...>
++  <Card className="group relative flex h-20 w-40 ..." compact allowInternalSpacingOverride>
++    <Image className="h-12 w-auto ..." />
++  </Card>
++</LogoCard>
+```
+
+### PricingCard
+```diff
+-<div className="relative ... rounded-2xl border-2 bg-white p-8 shadow-lg">
+-  {tier.recommended && (
+-    <div className="absolute left-1/2 top-6 ... bg-gradient-to-r from-blue-600 to-cyan-600 ...">
+-      MOST POPULAR
+-    </div>
+-  )}
+-  <button className="w-full rounded-lg px-6 py-3 ...">
+-    Get Started
+-  </button>
+-</div>
++<Card variant={tier.recommended ? "elevated" : "default"} className="relative w-full">
++  {tier.recommended ? (
++    <Badge tone="accent" variant="solid" icon={<Sparkles className="h-4 w-4" />}>Most popular</Badge>
++  ) : null}
++  <CardContent className="gap-6">
++    <Button
++      fullWidth
++      tone={tier.recommended ? "accent" : "neutral"}
++      variant="solid"
++      size="lg"
++      loading={isLoading}
++    >
++      Get started
++    </Button>
++  </CardContent>
++</Card>
+```
+
+### ScoreChart
+```diff
+-const toneClassMap = { success: "text-success", warning: "text-warning", error: "text-error" }
+-...
+-{showStatus && (
+-  <span className={cn("text-sm font-medium", toneClass)}>
+-    {getScoreStatus(displayScore)}
+-  </span>
+-)}
++const toneClassMap = { success: "text-success", warning: "text-warning", danger: "text-error" }
++...
++{showStatus ? (
++  <Badge tone={tone} variant="soft" size="sm">
++    {getScoreStatus(displayScore)}
++  </Badge>
++) : null}
+```
+
+## Dark Mode Validation
+- Verified components under a `.dark` root with Storybook controls: surfaces inherit `bg-surface`, text uses `text-foreground`/`text-muted-foreground`, and badges/buttons respect semantic tones in dark theme.
+- `TrustedBySection` gradient masks now reference `background` tokens to avoid washed-out fades.
+
+## Outstanding TODOs & Follow-ups
+- Codemod heuristics insert `// TODO(ds-migration)` comments when encountering unmapped local token usages or unknown hex literals. Review and replace these with the closest semantic classes as they appear.
+- Monitor `eslint-plugin-tailwindcss` for a stable Tailwind v4-compatible release so we can drop the beta pin once it ships.
+- Expand codemod coverage to marketing landing pages outside the initial scope (e.g., hero sections) after validating current passes on CI.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,6 +55,8 @@ const eslintConfig = [
     rules: {
       "design/no-tailwind-arbitrary-values": "off",
       "design/no-raw-colors": "off",
+      "@typescript-eslint/no-require-imports": "off",
+      "@typescript-eslint/no-var-requires": "off",
     },
   },
 ];

--- a/lib/design-system/component-registry.ts
+++ b/lib/design-system/component-registry.ts
@@ -1,0 +1,28 @@
+/**
+ * Canonical React component entrypoints for the Testero design system.
+ *
+ * These exports intentionally point to the runtime implementations that live
+ * under `components/ui` and `components/patterns`. Consolidating them in one
+ * place allows feature code and codemods to consume primitives through a
+ * stable, token-backed surface without reaching into ad-hoc paths.
+ */
+
+export { Button, type ButtonProps } from "@/components/ui/button";
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardAction,
+  cardVariants,
+  type CardProps,
+} from "@/components/ui/card";
+export { Badge, type BadgeProps, badgeVariants } from "@/components/ui/badge";
+export { PageHeader, type PageHeaderProps } from "@/components/ui/page-header";
+export { EmptyState, type EmptyStateProps } from "@/components/ui/empty-state";
+export { Table, type TableProps } from "@/components/ui/table";
+export { Toast, type ToastProps } from "@/components/ui/toast";
+export { Container, type ContainerProps } from "@/components/patterns/Container";
+export { Section, type SectionProps } from "@/components/patterns/section";

--- a/lib/design-system/index.ts
+++ b/lib/design-system/index.ts
@@ -81,6 +81,8 @@ export {
   card as legacyCard
 } from './components';
 
+export * from './component-registry';
+
 
 // Design system metadata
 export const designSystemVersion = '2.0.0';

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,17 +87,23 @@
         "dotenv": "^16.5.0",
         "eslint": "^9",
         "eslint-config-next": "15.3.1",
+        "eslint-plugin-tailwindcss": "^4.0.0-beta.0",
         "fast-xml-parser": "^5.2.3",
         "http-server": "^14.1.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "jscodeshift": "^0.15.2",
+        "lint-staged": "^15.2.10",
         "minimatch": "^9.0.5",
         "prettier": "^3.5.3",
         "sharp": "^0.34.1",
+        "simple-git-hooks": "^2.9.0",
         "storybook": "^8.6.14",
         "tailwindcss": "^4",
         "ts-jest": "^29.3.4",
+        "ts-morph": "^22.0.0",
         "ts-node": "^10.9.2",
+        "tsx": "^4.19.2",
         "typescript": "^5.8.3"
       }
     },
@@ -309,6 +315,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
@@ -336,11 +355,57 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz",
+      "integrity": "sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-member-expression-to-functions": "^7.27.1",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.28.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
+      "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -376,12 +441,57 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
       "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
+      "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.27.1",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -490,6 +600,22 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-flow": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.27.1.tgz",
+      "integrity": "sha512-p9OkPbZ5G7UT1MofwYFigGebnrzGJacoBSQM0/6bi/PUMVE+qlWDD/OalvQKbwgQzU6dl0xAv6r4X7Jme0RYxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -680,6 +806,324 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-properties": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
+      "integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-flow-strip-types": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.27.1.tgz",
+      "integrity": "sha512-G5eDKsu50udECw7DL2AcsysXiQyB7Nfg521t2OAJ4tbfTJ27doHLeF/vlI1NZGlLdbb/v+ibvtL1YBQqYOwJGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-syntax-flow": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
+      "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
+      "integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-chaining": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
+      "integrity": "sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-methods": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz",
+      "integrity": "sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
+      "integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-flow": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.27.1.tgz",
+      "integrity": "sha512-ez3a2it5Fn6P54W8QkbfIyyIbxlXvcxyWHHvno1Wg0Ej5eiJY5hBb8ExttoIOJJk7V2dZE6prP7iby5q2aQ0Lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-transform-flow-strip-types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/register": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.28.3.tgz",
+      "integrity": "sha512-CieDOtd8u208eI49bYl4z1J22ySFw87IGwE+IswFEExH7e3rLgKb0WNQeumnacQ1+VoDJLYI5QFA3AJZuyZQfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "find-cache-dir": "^2.0.0",
+        "make-dir": "^2.1.0",
+        "pirates": "^4.0.6",
+        "source-map-support": "^0.5.16"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/register/node_modules/find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/register/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/register/node_modules/pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@babel/register/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/register/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -3228,6 +3672,19 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.53.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.0.tgz",
@@ -5067,6 +5524,49 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.23.0.tgz",
+      "integrity": "sha512-m7Lllj9n/S6sOkCkRftpM7L24uvmfXQFedlW/4hENcuJH1HHm9u5EgxZb9uVjQSCGrbBWBkOGgcTxNg36r6ywA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.3.2",
+        "minimatch": "^9.0.3",
+        "mkdirp": "^3.0.1",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -7135,6 +7635,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/babel-core": {
+      "version": "7.0.0-bridge.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -7951,6 +8461,93 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -7972,6 +8569,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -7991,6 +8603,13 @@
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/collapse-white-space": {
       "version": "2.1.0",
@@ -8110,6 +8729,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -9137,6 +9763,19 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -9882,6 +10521,25 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-tailwindcss": {
+      "version": "4.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-4.0.0-beta.0.tgz",
+      "integrity": "sha512-WWCajZgQu38Sd67ZCl2W6i3MRzqB0d+H8s4qV9iB6lBJbsDOIpIlj6R1Fj2FXkoWErbo05pZnZYbCGIU9o/DsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.2.5",
+        "postcss": "^8.4.4",
+        "synckit": "^0.11.4",
+        "tailwind-api-utils": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.4.0 || ^4.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -10188,6 +10846,13 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/exsolve": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
+      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -10471,6 +11136,16 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/flow-parser": {
+      "version": "0.285.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.285.0.tgz",
+      "integrity": "sha512-HyZ+aPQLxf30nzywqPQnwVrm0rQ7yABuqQpV0yLFvuYPtVkXJxMs14LDj3Z1BqRclBiWuBWfNdtDHpzCzmHcKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
@@ -10780,6 +11455,19 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -12256,6 +12944,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -12446,6 +13147,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -13544,6 +14255,58 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jscodeshift": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.15.2.tgz",
+      "integrity": "sha512-FquR7Okgmc4Sd0aEDwqho3rEiKR3BdvuG9jfdHjLJ6JQoWSMpavug3AoIfnfWhxFlf+5pzQh8qjqz0DWFrNQzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.23.0",
+        "@babel/parser": "^7.23.0",
+        "@babel/plugin-transform-class-properties": "^7.22.5",
+        "@babel/plugin-transform-modules-commonjs": "^7.23.0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.22.11",
+        "@babel/plugin-transform-optional-chaining": "^7.23.0",
+        "@babel/plugin-transform-private-methods": "^7.22.5",
+        "@babel/preset-flow": "^7.22.15",
+        "@babel/preset-typescript": "^7.23.0",
+        "@babel/register": "^7.22.15",
+        "babel-core": "^7.0.0-bridge.0",
+        "chalk": "^4.1.2",
+        "flow-parser": "0.*",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^4.0.4",
+        "neo-async": "^2.5.0",
+        "node-dir": "^0.1.17",
+        "recast": "^0.23.3",
+        "temp": "^0.8.4",
+        "write-file-atomic": "^2.3.0"
+      },
+      "bin": {
+        "jscodeshift": "bin/jscodeshift.js"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/preset-env": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jscodeshift/node_modules/write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.8.0.tgz",
@@ -14131,11 +14894,342 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
+    },
+    "node_modules/lint-staged": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
+      "integrity": "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "debug": "^4.4.0",
+        "execa": "^8.0.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.2.5",
+        "micromatch": "^4.0.8",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.7.0"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/lint-staged/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/lint-staged/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/lint-staged/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
+      "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/loader-runner": {
       "version": "4.3.0",
@@ -14145,6 +15239,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
+      "integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.3.0",
+        "quansync": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/locate-path": {
@@ -14196,6 +15308,160 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.1.0.tgz",
+      "integrity": "sha512-YdhtCd19sKRKfAAUsrcC1wzm4JuzJoiX4pOJqIoW2qmKj5WzG/dL8uUJ0361zaXtHqK7gEhOwtAtz7t3Yq3X5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -15459,6 +16725,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -15532,6 +16811,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/mlly/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
       }
     },
     "node_modules/motion-dom": {
@@ -15731,6 +17042,43 @@
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-dir": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+      "integrity": "sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.5"
+      }
+    },
+    "node_modules/node-dir/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/node-dir/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -16221,6 +17569,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pathval": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
@@ -16257,6 +17612,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pirates": {
@@ -16336,6 +17714,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
+        "pathe": "^2.0.3"
       }
     },
     "node_modules/playwright": {
@@ -16789,6 +18179,23 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -18001,6 +19408,52 @@
         "node": ">=10"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -18034,6 +19487,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -18347,6 +19807,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/sharp": {
       "version": "0.34.3",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.3.tgz",
@@ -18492,6 +19965,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-git-hooks": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.13.1.tgz",
+      "integrity": "sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "simple-git-hooks": "cli.js"
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -18524,6 +20008,49 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/source-map": {
@@ -18674,6 +20201,16 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-length": {
@@ -19054,6 +20591,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/synckit": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
+      "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tailwind-api-utils": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.3.tgz",
+      "integrity": "sha512-KpzUHkH1ug1sq4394SLJX38ZtpeTiqQ1RVyFTTSY2XuHsNSTWUkRo108KmyyrMWdDbQrLYkSHaNKj/a3bmA4sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "enhanced-resolve": "^5.18.1",
+        "jiti": "^2.4.2",
+        "local-pkg": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hyoban"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.3.0 || ^4.0.0 || ^4.0.0-beta"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
@@ -19161,6 +20732,33 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/temp": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
+      "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rimraf": "~2.6.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/temp/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/terser": {
@@ -19546,6 +21144,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ts-morph": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-22.0.0.tgz",
+      "integrity": "sha512-M9MqFGZREyeb5fTl6gNHKZLqBQA0TjA1lea+CR48R8EBTDuWrNqW6ccC5QvjNR4s6wDumD3LTCjOFSp9iwlzaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.23.0",
+        "code-block-writer": "^13.0.1"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -19631,6 +21240,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz",
+      "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -19759,6 +21388,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,11 @@
     "e2e:ui": "playwright test --ui",
     "e2e:debug": "playwright test --debug",
     "e2e:headed": "playwright test --headed",
-    "e2e:report": "playwright show-report"
+    "e2e:report": "playwright show-report",
+    "codemod:ds:run": "tsx scripts/codemods/ds/run-all.ts",
+    "codemod:ds:dry": "tsx scripts/codemods/ds/run-all.ts --dry",
+    "lint:design": "node scripts/guards/design-lints.js",
+    "prepare": "node scripts/setup-tailwindcss-eslint-shim.js && simple-git-hooks"
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.22",
@@ -107,18 +111,31 @@
     "cross-env": "^7.0.3",
     "dotenv": "^16.5.0",
     "eslint": "^9",
+    "eslint-plugin-tailwindcss": "^4.0.0-beta.0",
     "eslint-config-next": "15.3.1",
     "fast-xml-parser": "^5.2.3",
     "http-server": "^14.1.1",
     "jest": "^29.7.0",
+    "jscodeshift": "^0.15.2",
     "jest-environment-jsdom": "^29.7.0",
     "minimatch": "^9.0.5",
     "prettier": "^3.5.3",
     "sharp": "^0.34.1",
+    "simple-git-hooks": "^2.9.0",
     "storybook": "^8.6.14",
     "tailwindcss": "^4",
+    "lint-staged": "^15.2.10",
+    "ts-morph": "^22.0.0",
     "ts-jest": "^29.3.4",
     "ts-node": "^10.9.2",
+    "tsx": "^4.19.2",
     "typescript": "^5.8.3"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx}": ["next lint --fix --file"],
+    "*.{css,scss,mdx}": ["next lint --fix --file"]
+  },
+  "simple-git-hooks": {
+    "pre-commit": "npx lint-staged"
   }
 }

--- a/scripts/codemods/ds/badge-and-status.ts
+++ b/scripts/codemods/ds/badge-and-status.ts
@@ -1,0 +1,166 @@
+import path from "node:path"
+
+import { JsxAttribute, JsxElement, Node, Project, QuoteKind, SyntaxKind } from "ts-morph"
+
+import {
+  collectFiles,
+  dedupeResults,
+  logResult,
+  parseArgs,
+  type CodemodCLIOptions,
+  type CodemodRunResult,
+} from "./utils"
+
+const toneMatchers: { match: RegExp; tone: string }[] = [
+  { match: /bg-(green|emerald|success)/, tone: "success" },
+  { match: /bg-(yellow|amber|warning)/, tone: "warning" },
+  { match: /bg-(red|rose|destructive|error)/, tone: "danger" },
+  { match: /bg-(blue|cyan|accent)/, tone: "accent" },
+  { match: /bg-(gray|slate|neutral)/, tone: "neutral" },
+]
+
+function getClassAttribute(element: JsxElement): JsxAttribute | undefined {
+  for (const attribute of element.getOpeningElement().getAttributes()) {
+    if (!Node.isJsxAttribute(attribute)) continue
+    const name = attribute.getNameNode().getText()
+    if (name === "className") {
+      return attribute
+    }
+  }
+  return undefined
+}
+
+function splitClasses(value: string) {
+  return value
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter(Boolean)
+}
+
+function determineTone(classes: string[]): string | undefined {
+  const classString = classes.join(" ")
+  for (const matcher of toneMatchers) {
+    if (matcher.match.test(classString)) {
+      return matcher.tone
+    }
+  }
+  return undefined
+}
+
+function looksLikeBadge(classes: string[]) {
+  return classes.includes("rounded-full") && classes.some((token) => token.startsWith("px-"))
+}
+
+function ensureBadgeImport(source: ReturnType<Project["addSourceFileAtPathIfExists"]>) {
+  if (!source) return
+  const existing = source.getImportDeclarations().find((decl) => decl.getModuleSpecifierValue() === "@/components/ui/badge")
+  if (existing) {
+    if (!existing.getNamedImports().some((named) => named.getName() === "Badge")) {
+      existing.addNamedImport({ name: "Badge" })
+    }
+    return
+  }
+  source.addImportDeclaration({ moduleSpecifier: "@/components/ui/badge", namedImports: [{ name: "Badge" }] })
+}
+
+function transformBadge(source: ReturnType<Project["addSourceFileAtPathIfExists"]>, element: JsxElement) {
+  const opening = element.getOpeningElement()
+  const closing = element.getClosingElement()
+  const classAttr = getClassAttribute(element)
+  if (!classAttr) return false
+  const initializer = classAttr.getInitializer()
+  if (!initializer || !Node.isStringLiteral(initializer)) {
+    return false
+  }
+
+  const classes = splitClasses(initializer.getLiteralValue())
+  if (!looksLikeBadge(classes)) {
+    return false
+  }
+
+  const tone = determineTone(classes)
+  const removablePrefixes = ["bg-", "text-", "shadow", "hover:", "px-", "py-", "uppercase", "tracking-", "font-bold", "font-semibold"]
+  const remaining = classes.filter((token) => !removablePrefixes.some((prefix) => token.startsWith(prefix)) && token !== "rounded-full")
+
+  if (remaining.length) {
+    initializer.setLiteralValue(Array.from(new Set(remaining)).join(" "))
+  } else {
+    classAttr.remove()
+  }
+
+  const tagName = opening.getTagNameNode().getText()
+  if (tagName !== "Badge") {
+    opening.getTagNameNode().replaceWithText("Badge")
+    closing?.getTagNameNode().replaceWithText("Badge")
+  }
+
+  if (tone) {
+    opening.addAttribute({ name: "tone", initializer: `"${tone}"` })
+  }
+  opening.addAttribute({ name: "variant", initializer: '"soft"' })
+  ensureBadgeImport(source)
+  return true
+}
+
+async function transformFile(project: Project, filePath: string, dry: boolean): Promise<CodemodRunResult> {
+  const source = project.addSourceFileAtPathIfExists(path.join(process.cwd(), filePath))
+  if (!source) {
+    return { file: filePath, applied: false, message: "missing source" }
+  }
+
+  let mutated = false
+
+  source.getDescendantsOfKind(SyntaxKind.JsxElement).forEach((element) => {
+    const tagName = element.getOpeningElement().getTagNameNode().getText()
+    if (tagName === "Badge") {
+      return
+    }
+
+    if (transformBadge(source, element)) {
+      mutated = true
+    }
+  })
+
+  if (!mutated) {
+    return { file: filePath, applied: false }
+  }
+
+  if (!dry) {
+    await source.save()
+  }
+
+  return { file: filePath, applied: true }
+}
+
+export async function apply(options: CodemodCLIOptions) {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    manipulationSettings: { quoteKind: QuoteKind.Double },
+  })
+
+  const files = await collectFiles(options)
+  const results: CodemodRunResult[] = []
+
+  for (const file of files) {
+    const result = await transformFile(project, file, options.dry)
+    if (options.verbose || result.applied) {
+      logResult("badge-and-status", result, options.dry)
+    }
+    results.push(result)
+  }
+
+  const summary = dedupeResults(results).filter((item) => item.applied)
+  if (summary.length && options.dry) {
+    console.log(`\n${summary.length} files would be updated by badge-and-status.`)
+  }
+}
+
+async function run() {
+  const options = parseArgs(process.argv.slice(2))
+  await apply(options)
+}
+
+run().catch((error) => {
+  console.error("badge-and-status failed", error)
+  process.exitCode = 1
+})

--- a/scripts/codemods/ds/button-to-ds-variants.ts
+++ b/scripts/codemods/ds/button-to-ds-variants.ts
@@ -1,0 +1,206 @@
+import path from "node:path"
+
+import { JsxAttribute, JsxElement, Node, Project, QuoteKind, SyntaxKind } from "ts-morph"
+
+import {
+  collectFiles,
+  dedupeResults,
+  logResult,
+  parseArgs,
+  type CodemodCLIOptions,
+  type CodemodRunResult,
+} from "./utils"
+
+const gradientTokens = [
+  "bg-gradient-to-r",
+  "from-blue-600",
+  "to-cyan-600",
+  "hover:from-blue-700",
+  "hover:to-cyan-700",
+]
+
+const neutralTokens = ["bg-gray-900", "hover:bg-gray-800", "text-white"]
+
+const spacingTokens = new Set(["px-6", "py-3", "px-5", "py-2", "rounded-lg", "rounded-2xl", "transition-all", "duration-200"])
+
+function getClassAttribute(element: JsxElement): JsxAttribute | undefined {
+  for (const attribute of element.getOpeningElement().getAttributes()) {
+    if (!Node.isJsxAttribute(attribute)) continue
+    const name = attribute.getNameNode().getText()
+    if (name === "className") {
+      return attribute
+    }
+  }
+  return undefined
+}
+
+function splitClasses(value: string) {
+  return value
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter(Boolean)
+}
+
+function determineSize(classes: string[]) {
+  if (classes.includes("py-3") || classes.includes("h-12")) return "lg"
+  if (classes.includes("py-2.5") || classes.includes("py-2")) return "md"
+  return undefined
+}
+
+function transformButton(source: ReturnType<Project["addSourceFileAtPathIfExists"]>, element: JsxElement) {
+  const opening = element.getOpeningElement()
+  const closing = element.getClosingElement()
+  const classAttr = getClassAttribute(element)
+  if (!classAttr) return false
+  const initializer = classAttr.getInitializer()
+  if (!initializer || !Node.isStringLiteral(initializer)) {
+    return false
+  }
+
+  const classes = splitClasses(initializer.getLiteralValue())
+  let tone: string | undefined
+  let variant: string | undefined
+  const removable = new Set<string>()
+
+  if (gradientTokens.every((token) => classes.includes(token))) {
+    tone = "accent"
+    variant = "solid"
+    gradientTokens.forEach((token) => removable.add(token))
+    removable.add("text-white")
+    removable.add("shadow-md")
+    removable.add("hover:shadow-lg")
+  }
+
+  if (!tone && neutralTokens.some((token) => classes.includes(token))) {
+    tone = "neutral"
+    variant = "solid"
+    neutralTokens.forEach((token) => removable.add(token))
+  }
+
+  const size = determineSize(classes)
+  if (size) {
+    spacingTokens.forEach((token) => {
+      if (classes.includes(token)) {
+        removable.add(token)
+      }
+    })
+  }
+
+  let fullWidth = false
+  if (classes.includes("w-full")) {
+    fullWidth = true
+    removable.add("w-full")
+  }
+
+  if (!tone && !variant && !fullWidth && !size) {
+    return false
+  }
+
+  const remainingClasses = classes.filter((token) => !removable.has(token))
+  if (remainingClasses.length) {
+    initializer.setLiteralValue(Array.from(new Set(remainingClasses)).join(" "))
+  } else {
+    classAttr.remove()
+  }
+
+  opening.getTagNameNode().replaceWithText("Button")
+  closing?.getTagNameNode().replaceWithText("Button")
+
+  if (variant) {
+    opening.addAttribute({ name: "variant", initializer: `"${variant}"` })
+  }
+  if (tone) {
+    opening.addAttribute({ name: "tone", initializer: `"${tone}"` })
+  }
+  if (size) {
+    opening.addAttribute({ name: "size", initializer: `"${size}"` })
+  }
+  if (fullWidth) {
+    opening.addAttribute({ name: "fullWidth" })
+  }
+
+  const hasTypeAttribute = opening
+    .getAttributes()
+    .some((attr) => Node.isJsxAttribute(attr) && attr.getNameNode().getText() === "type")
+  if (!hasTypeAttribute) {
+    opening.addAttribute({ name: "type", initializer: '"button"' })
+  }
+
+  ensureButtonImport(source)
+  return true
+}
+
+function ensureButtonImport(source: ReturnType<Project["addSourceFileAtPathIfExists"]>) {
+  if (!source) return
+  const existing = source.getImportDeclarations().find((decl) => decl.getModuleSpecifierValue() === "@/components/ui/button")
+  if (existing) {
+    if (!existing.getNamedImports().some((named) => named.getName() === "Button")) {
+      existing.addNamedImport({ name: "Button" })
+    }
+    return
+  }
+  source.addImportDeclaration({ moduleSpecifier: "@/components/ui/button", namedImports: [{ name: "Button" }] })
+}
+
+async function transformFile(project: Project, filePath: string, dry: boolean): Promise<CodemodRunResult> {
+  const source = project.addSourceFileAtPathIfExists(path.join(process.cwd(), filePath))
+  if (!source) {
+    return { file: filePath, applied: false, message: "missing source" }
+  }
+
+  let mutated = false
+
+  source.getDescendantsOfKind(SyntaxKind.JsxElement).forEach((element) => {
+    const tagName = element.getOpeningElement().getTagNameNode().getText()
+    if (tagName !== "button") {
+      return
+    }
+
+    if (transformButton(source, element)) {
+      mutated = true
+    }
+  })
+
+  if (!mutated) {
+    return { file: filePath, applied: false }
+  }
+
+  if (!dry) {
+    await source.save()
+  }
+
+  return { file: filePath, applied: true }
+}
+
+export async function apply(options: CodemodCLIOptions) {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    manipulationSettings: { quoteKind: QuoteKind.Double },
+  })
+
+  const files = await collectFiles(options)
+  const results: CodemodRunResult[] = []
+
+  for (const file of files) {
+    const result = await transformFile(project, file, options.dry)
+    if (options.verbose || result.applied) {
+      logResult("button-to-ds-variants", result, options.dry)
+    }
+    results.push(result)
+  }
+
+  const summary = dedupeResults(results).filter((item) => item.applied)
+  if (summary.length && options.dry) {
+    console.log(`\n${summary.length} files would be updated by button-to-ds-variants.`)
+  }
+}
+
+async function run() {
+  const options = parseArgs(process.argv.slice(2))
+  await apply(options)
+}
+
+run().catch((error) => {
+  console.error("button-to-ds-variants failed", error)
+  process.exitCode = 1
+})

--- a/scripts/codemods/ds/hex-to-semantic.ts
+++ b/scripts/codemods/ds/hex-to-semantic.ts
@@ -1,0 +1,136 @@
+import path from "node:path"
+
+import { Node, Project, QuoteKind } from "ts-morph"
+
+import {
+  collectFiles,
+  dedupeResults,
+  logResult,
+  parseArgs,
+  type CodemodCLIOptions,
+  type CodemodRunResult,
+} from "./utils"
+
+const hexPattern = /#(?:[0-9a-fA-F]{3,8})/g
+const tokenMap = new Map<string, string>([
+  ["#22c55e", "hsl(var(--success))"],
+  ["#16a34a", "hsl(var(--success))"],
+  ["#15803d", "hsl(var(--success))"],
+  ["#f59e0b", "hsl(var(--warning))"],
+  ["#f97316", "hsl(var(--warning))"],
+  ["#ef4444", "hsl(var(--destructive))"],
+  ["#dc2626", "hsl(var(--destructive))"],
+  ["#0ea5e9", "hsl(var(--info))"],
+  ["#38bdf8", "hsl(var(--info))"],
+  ["#3b82f6", "hsl(var(--accent))"],
+  ["#2563eb", "hsl(var(--accent))"],
+])
+
+function uniqueHexes(value: string) {
+  const matches = value.match(hexPattern)
+  if (!matches) return []
+  return Array.from(new Set(matches.map((item) => item.toLowerCase())))
+}
+
+function transformLiteral(node: Node): boolean {
+  if (!Node.isStringLiteral(node) && !Node.isNoSubstitutionTemplateLiteral(node)) {
+    return false
+  }
+
+  const value = Node.isStringLiteral(node) ? node.getLiteralValue() : node.getLiteralText()
+  const found = uniqueHexes(value)
+  if (found.length === 0) {
+    return false
+  }
+
+  let updated = value
+  const unknown: string[] = []
+
+  for (const hex of found) {
+    const mapped = tokenMap.get(hex)
+    if (mapped) {
+      const regex = new RegExp(hex, "gi")
+      updated = updated.replace(regex, mapped)
+    } else {
+      unknown.push(hex)
+    }
+  }
+
+  if (Node.isStringLiteral(node)) {
+    if (updated !== value) {
+      node.setLiteralValue(updated)
+    }
+  } else if (Node.isNoSubstitutionTemplateLiteral(node)) {
+    if (updated !== value) {
+      node.replaceWithText("`" + updated + "`")
+    }
+  }
+
+  if (unknown.length > 0) {
+    const existingText = node.getText()
+    if (!existingText.startsWith("/* TODO(ds-migration)")) {
+      const comment = `/* TODO(ds-migration): replace ${unknown.join(", ")} with semantic design tokens */ `
+      node.replaceWithText(comment + existingText)
+    }
+  }
+
+  return true
+}
+
+async function transformFile(project: Project, filePath: string, dry: boolean): Promise<CodemodRunResult> {
+  const source = project.addSourceFileAtPathIfExists(path.join(process.cwd(), filePath))
+  if (!source) {
+    return { file: filePath, applied: false, message: "missing source" }
+  }
+
+  let mutated = false
+
+  source.forEachDescendant((node) => {
+    if (transformLiteral(node)) {
+      mutated = true
+    }
+  })
+
+  if (!mutated) {
+    return { file: filePath, applied: false }
+  }
+
+  if (!dry) {
+    await source.save()
+  }
+
+  return { file: filePath, applied: true }
+}
+
+export async function apply(options: CodemodCLIOptions) {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    manipulationSettings: { quoteKind: QuoteKind.Double },
+  })
+
+  const files = await collectFiles(options)
+  const results: CodemodRunResult[] = []
+
+  for (const file of files) {
+    const result = await transformFile(project, file, options.dry)
+    if (options.verbose || result.applied) {
+      logResult("hex-to-semantic", result, options.dry)
+    }
+    results.push(result)
+  }
+
+  const summary = dedupeResults(results).filter((item) => item.applied)
+  if (summary.length && options.dry) {
+    console.log(`\n${summary.length} files would be updated by hex-to-semantic.`)
+  }
+}
+
+async function run() {
+  const options = parseArgs(process.argv.slice(2))
+  await apply(options)
+}
+
+run().catch((error) => {
+  console.error("hex-to-semantic failed", error)
+  process.exitCode = 1
+})

--- a/scripts/codemods/ds/remove-local-designTokens.ts
+++ b/scripts/codemods/ds/remove-local-designTokens.ts
@@ -1,0 +1,142 @@
+import path from "node:path"
+
+import { Node, Project, QuoteKind } from "ts-morph"
+
+import {
+  collectFiles,
+  dedupeResults,
+  logResult,
+  parseArgs,
+  type CodemodCLIOptions,
+  type CodemodRunResult,
+} from "./utils"
+
+const DESIGN_TOKEN_IDENTIFIER = "designTokens"
+
+const replacementMap = new Map<string, string>([
+  ["colors.text.primary", '"text-foreground"'],
+  ["colors.text.secondary", '"text-muted-foreground"'],
+  ["colors.text.muted", '"text-muted-foreground"'],
+  ["colors.logo.container", '"bg-surface-muted"'],
+  ["colors.logo.border", '"border-border/60"'],
+  ["typography.sectionTitle", '"text-3xl font-semibold tracking-tight"'],
+  ["typography.subtitle", '"text-base text-muted-foreground"'],
+  ["spacing.logo", '"h-12"'],
+  ["spacing.logoContainer", '"h-24"'],
+  ["effects.logoHover", '"transition-transform duration-200"'],
+])
+
+function getDesignTokenPath(node: Node): { expression: Node; path: string; segments: string[] } | null {
+  if (!Node.isPropertyAccessExpression(node)) {
+    return null
+  }
+
+  const parts: string[] = []
+  let current: Node | undefined = node
+
+  while (Node.isPropertyAccessExpression(current)) {
+    parts.unshift(current.getName())
+    current = current.getExpression()
+  }
+
+  if (!current || !Node.isIdentifier(current)) {
+    return null
+  }
+
+  if (current.getText() !== DESIGN_TOKEN_IDENTIFIER) {
+    return null
+  }
+
+  return { expression: node, path: parts.join("."), segments: parts }
+}
+
+async function transformFile(project: Project, filePath: string, dry: boolean): Promise<CodemodRunResult> {
+  const source = project.addSourceFileAtPathIfExists(path.join(process.cwd(), filePath))
+  if (!source) {
+    return { file: filePath, applied: false, message: "missing source" }
+  }
+
+  let mutated = false
+
+  source.forEachDescendant((node) => {
+    if (!Node.isPropertyAccessExpression(node)) {
+      return
+    }
+
+    const info = getDesignTokenPath(node)
+    if (!info) {
+      return
+    }
+
+    const replacement = replacementMap.get(info.path)
+    if (replacement) {
+      node.replaceWithText(replacement)
+      mutated = true
+      return
+    }
+
+    const fallback = `legacyDesignTokens.${info.segments.join(".")}`
+    node.replaceWithText(`/* TODO(ds-migration): map ${info.path} */ ${fallback}`)
+    mutated = true
+  })
+
+  const declaration = source.getVariableDeclaration(DESIGN_TOKEN_IDENTIFIER)
+  if (declaration) {
+    const initializer = declaration.getInitializer()?.getText() ?? "{}"
+    const variableStatement = declaration.getVariableStatement()
+    const declarationKind = variableStatement?.getDeclarationKind() ?? "const"
+
+    if (variableStatement) {
+      variableStatement.setIsExported(false)
+      variableStatement.replaceWithText((writer) => {
+        writer.writeLine(`// TODO(ds-migration): replace legacyDesignTokens with design-system primitives`)
+        writer.write(`${declarationKind} legacyDesignTokens = ${initializer}`)
+        writer.write(";")
+      })
+    }
+    mutated = true
+  }
+
+  if (!mutated) {
+    return { file: filePath, applied: false }
+  }
+
+  if (!dry) {
+    await source.save()
+  }
+
+  return { file: filePath, applied: true }
+}
+
+export async function apply(options: CodemodCLIOptions) {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    manipulationSettings: { quoteKind: QuoteKind.Double },
+  })
+
+  const files = await collectFiles(options)
+  const results: CodemodRunResult[] = []
+
+  for (const file of files) {
+    const result = await transformFile(project, file, options.dry)
+    if (options.verbose || result.applied) {
+      logResult("remove-local-designTokens", result, options.dry)
+    }
+    results.push(result)
+  }
+
+  const summary = dedupeResults(results).filter((item) => item.applied)
+  if (summary.length && options.dry) {
+    console.log(`\n${summary.length} files would be updated by remove-local-designTokens.`)
+  }
+}
+
+async function run() {
+  const options = parseArgs(process.argv.slice(2))
+  await apply(options)
+}
+
+run().catch((error) => {
+  console.error("remove-local-designTokens failed", error)
+  process.exitCode = 1
+})

--- a/scripts/codemods/ds/run-all.ts
+++ b/scripts/codemods/ds/run-all.ts
@@ -1,0 +1,30 @@
+import { parseArgs, type CodemodCLIOptions } from "./utils"
+import { apply as removeLocalDesignTokens } from "./remove-local-designTokens"
+import { apply as wrapWithContainerSection } from "./wrap-with-container-section"
+import { apply as buttonToDsVariants } from "./button-to-ds-variants"
+import { apply as badgeAndStatus } from "./badge-and-status"
+import { apply as hexToSemantic } from "./hex-to-semantic"
+
+const codemods: { name: string; run: (options: CodemodCLIOptions) => Promise<void> }[] = [
+  { name: "remove-local-designTokens", run: removeLocalDesignTokens },
+  { name: "wrap-with-container-section", run: wrapWithContainerSection },
+  { name: "button-to-ds-variants", run: buttonToDsVariants },
+  { name: "badge-and-status", run: badgeAndStatus },
+  { name: "hex-to-semantic", run: hexToSemantic },
+]
+
+async function run() {
+  const options = parseArgs(process.argv.slice(2))
+
+  for (const codemod of codemods) {
+    console.log(`\n▶ Running ${codemod.name}${options.dry ? " (dry run)" : ""}`)
+    await codemod.run(options)
+  }
+
+  console.log("\n✅ Design system codemods completed")
+}
+
+run().catch((error) => {
+  console.error("codemod orchestrator failed", error)
+  process.exitCode = 1
+})

--- a/scripts/codemods/ds/utils.ts
+++ b/scripts/codemods/ds/utils.ts
@@ -1,0 +1,128 @@
+import { promises as fs } from "node:fs"
+import path from "node:path"
+
+import { minimatch } from "minimatch"
+
+export type CodemodCLIOptions = {
+  dry: boolean
+  include: string[]
+  exclude: string[]
+  verbose: boolean
+}
+
+export type CodemodRunResult = {
+  file: string
+  applied: boolean
+  message?: string
+}
+
+const DEFAULT_IGNORES = new Set([
+  "node_modules",
+  ".next",
+  ".git",
+  "storybook-static",
+  "dist",
+  "build",
+  "coverage",
+])
+
+export function parseArgs(argv: string[]): CodemodCLIOptions {
+  const options: CodemodCLIOptions = {
+    dry: false,
+    include: ["components/**/*.tsx", "app/**/*.tsx", "lib/**/*.tsx"],
+    exclude: ["**/__tests__/**", "**/*.stories.tsx", "**/*.spec.tsx"],
+    verbose: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === "--dry") {
+      options.dry = true
+      continue
+    }
+    if (arg === "--verbose") {
+      options.verbose = true
+      continue
+    }
+    if (arg === "--include") {
+      const value = argv[index + 1]
+      if (!value) {
+        throw new Error("Missing value for --include")
+      }
+      options.include.push(value)
+      index += 1
+      continue
+    }
+    if (arg === "--exclude") {
+      const value = argv[index + 1]
+      if (!value) {
+        throw new Error("Missing value for --exclude")
+      }
+      options.exclude.push(value)
+      index += 1
+      continue
+    }
+  }
+
+  return options
+}
+
+export async function collectFiles({ include, exclude }: Pick<CodemodCLIOptions, "include" | "exclude">) {
+  const root = process.cwd()
+  const files: string[] = []
+
+  async function walk(currentDir: string) {
+    const entries = await fs.readdir(currentDir, { withFileTypes: true })
+    for (const entry of entries) {
+      if (DEFAULT_IGNORES.has(entry.name)) continue
+
+      const absolutePath = path.join(currentDir, entry.name)
+      const relativePath = path.relative(root, absolutePath).split(path.sep).join("/")
+
+      if (entry.isDirectory()) {
+        await walk(absolutePath)
+        continue
+      }
+
+      if (!include.some((pattern) => minimatch(relativePath, pattern, { dot: true }))) {
+        continue
+      }
+
+      if (exclude.some((pattern) => minimatch(relativePath, pattern, { dot: true }))) {
+        continue
+      }
+
+      files.push(relativePath)
+    }
+  }
+
+  await walk(root)
+  return files.sort()
+}
+
+export async function readFile(filePath: string) {
+  const absolutePath = path.join(process.cwd(), filePath)
+  return fs.readFile(absolutePath, "utf8")
+}
+
+export async function writeFile(filePath: string, contents: string) {
+  const absolutePath = path.join(process.cwd(), filePath)
+  await fs.writeFile(absolutePath, contents, "utf8")
+}
+
+export function logResult(modName: string, result: CodemodRunResult, dry: boolean) {
+  const action = result.applied ? (dry ? "would update" : "updated") : "skipped"
+  const details = result.message ? ` → ${result.message}` : ""
+  console.log(`[${modName}] ${action} ${result.file}${details}`)
+}
+
+export function dedupeResults(results: CodemodRunResult[]) {
+  const seen = new Map<string, CodemodRunResult>()
+  for (const result of results) {
+    const existing = seen.get(result.file)
+    if (!existing || result.applied) {
+      seen.set(result.file, result)
+    }
+  }
+  return Array.from(seen.values())
+}

--- a/scripts/codemods/ds/wrap-with-container-section.ts
+++ b/scripts/codemods/ds/wrap-with-container-section.ts
@@ -1,0 +1,200 @@
+import path from "node:path"
+
+import { JsxAttribute, JsxElement, Node, Project, QuoteKind, SyntaxKind } from "ts-morph"
+
+import {
+  collectFiles,
+  dedupeResults,
+  logResult,
+  parseArgs,
+  type CodemodCLIOptions,
+  type CodemodRunResult,
+} from "./utils"
+
+const containerTokens = ["max-w-7xl", "mx-auto", "px-4", "sm:px-6", "lg:px-8"]
+
+const sectionPatterns = [
+  { tokens: ["py-12", "md:py-16"], size: "md" as const },
+  { tokens: ["py-16", "md:py-20"], size: "lg" as const },
+  { tokens: ["py-20", "lg:py-24"], size: "xl" as const },
+  { tokens: ["py-8"], size: "sm" as const },
+]
+
+function splitClasses(value: string) {
+  return value
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter(Boolean)
+}
+
+function removeTokens(value: string, tokens: string[]) {
+  const classes = splitClasses(value)
+  const remaining = classes.filter((token) => !tokens.includes(token))
+  const removed = classes.filter((token) => tokens.includes(token))
+  return {
+    remaining: Array.from(new Set(remaining)).join(" ").trim(),
+    removed,
+  }
+}
+
+function ensureImport(source: ReturnType<Project["addSourceFileAtPathIfExists"]>, name: string, moduleSpecifier: string) {
+  if (!source) return
+  const existing = source.getImportDeclarations().find((decl) => decl.getModuleSpecifierValue() === moduleSpecifier)
+  if (existing) {
+    if (!existing.getNamedImports().some((named) => named.getName() === name)) {
+      existing.addNamedImport({ name })
+    }
+    return
+  }
+  source.addImportDeclaration({ moduleSpecifier, namedImports: [{ name }] })
+}
+
+function getClassAttribute(element: JsxElement): JsxAttribute | undefined {
+  for (const attribute of element.getOpeningElement().getAttributes()) {
+    if (!Node.isJsxAttribute(attribute)) continue
+    const name = attribute.getNameNode().getText()
+    if (name === "className") {
+      return attribute
+    }
+  }
+  return undefined
+}
+
+function wrapWithContainer(source: ReturnType<Project["addSourceFileAtPathIfExists"]>, element: JsxElement) {
+  const classAttr = getClassAttribute(element)
+  if (!classAttr) return false
+
+  const initializer = classAttr.getInitializer()
+  if (!initializer || !Node.isStringLiteral(initializer)) {
+    return false
+  }
+
+  const { remaining } = removeTokens(initializer.getLiteralValue(), containerTokens)
+  if (remaining === initializer.getLiteralValue()) {
+    return false
+  }
+
+  if (remaining) {
+    initializer.setLiteralValue(remaining)
+  } else {
+    classAttr.remove()
+  }
+
+  const indent = element.getIndentationText() ?? ""
+  const indentUnit = element.getSourceFile().getIndentationText()
+  const replacement = `${indent}<Container>\n${indent}${indentUnit}${element.getText()}\n${indent}</Container>`
+  element.replaceWithText(replacement)
+  ensureImport(source, "Container", "@/components/patterns")
+  return true
+}
+
+function detectSectionSize(value: string) {
+  for (const pattern of sectionPatterns) {
+    const tokensPresent = pattern.tokens.every((token) => value.includes(token))
+    if (tokensPresent) {
+      return pattern
+    }
+  }
+  return null
+}
+
+function wrapWithSection(source: ReturnType<Project["addSourceFileAtPathIfExists"]>, element: JsxElement) {
+  const classAttr = getClassAttribute(element)
+  if (!classAttr) return false
+  const initializer = classAttr.getInitializer()
+  if (!initializer || !Node.isStringLiteral(initializer)) {
+    return false
+  }
+
+  const pattern = detectSectionSize(initializer.getLiteralValue())
+  if (!pattern) {
+    return false
+  }
+
+  const { remaining } = removeTokens(initializer.getLiteralValue(), pattern.tokens)
+  if (remaining) {
+    initializer.setLiteralValue(remaining)
+  } else {
+    classAttr.remove()
+  }
+
+  const indent = element.getIndentationText() ?? ""
+  const indentUnit = element.getSourceFile().getIndentationText()
+  const sizeProp = pattern.size ? ` size=\"${pattern.size}\"` : ""
+  const replacement = `${indent}<Section${sizeProp}>\n${indent}${indentUnit}${element.getText()}\n${indent}</Section>`
+  element.replaceWithText(replacement)
+  ensureImport(source, "Section", "@/components/patterns")
+  return true
+}
+
+async function transformFile(project: Project, filePath: string, dry: boolean): Promise<CodemodRunResult> {
+  const source = project.addSourceFileAtPathIfExists(path.join(process.cwd(), filePath))
+  if (!source) {
+    return { file: filePath, applied: false, message: "missing source" }
+  }
+
+  let mutated = false
+
+  source.getDescendantsOfKind(SyntaxKind.JsxElement).forEach((element) => {
+    if (Node.isJsxOpeningElement(element.getParent())) {
+      return
+    }
+
+    const tagName = element.getOpeningElement().getTagNameNode().getText()
+    if (tagName === "Container" || tagName === "Section") {
+      return
+    }
+
+    if (wrapWithContainer(source, element)) {
+      mutated = true
+      return
+    }
+
+    if (wrapWithSection(source, element)) {
+      mutated = true
+    }
+  })
+
+  if (!mutated) {
+    return { file: filePath, applied: false }
+  }
+
+  if (!dry) {
+    await source.save()
+  }
+
+  return { file: filePath, applied: true }
+}
+
+export async function apply(options: CodemodCLIOptions) {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    manipulationSettings: { quoteKind: QuoteKind.Double },
+  })
+
+  const files = await collectFiles(options)
+  const results: CodemodRunResult[] = []
+
+  for (const file of files) {
+    const result = await transformFile(project, file, options.dry)
+    if (options.verbose || result.applied) {
+      logResult("wrap-with-container-section", result, options.dry)
+    }
+    results.push(result)
+  }
+
+  const summary = dedupeResults(results).filter((item) => item.applied)
+  if (summary.length && options.dry) {
+    console.log(`\n${summary.length} files would be updated by wrap-with-container-section.`)
+  }
+}
+
+async function run() {
+  const options = parseArgs(process.argv.slice(2))
+  await apply(options)
+}
+
+run().catch((error) => {
+  console.error("wrap-with-container-section failed", error)
+  process.exitCode = 1
+})

--- a/scripts/guards/design-lints.js
+++ b/scripts/guards/design-lints.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+ 
+const { readdir, readFile } = require("node:fs/promises")
+const { existsSync } = require("node:fs")
+const path = require("node:path")
+
+const root = process.cwd()
+const includeDirs = [
+  path.join("components", "sections"),
+  path.join("components", "pricing"),
+  path.join("components", "marketing"),
+  path.join("components", "diagnostic"),
+]
+const ignoredDirs = new Set(["node_modules", ".next", "storybook-static", ".git"])
+const validExtensions = new Set([".ts", ".tsx", ".css", ".scss", ".mdx", ".jsx"])
+const ignoredPathFragments = [
+  path.join("components", "marketing", "forms"),
+  path.join("components", "marketing", "navigation"),
+]
+
+const hexPattern = /#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b/g
+const arbitraryValuePattern = /\[[^\]]*(?:#[0-9a-fA-F]{3,8}|rgba?\(|hsla?\(|px)/g
+
+async function collectFiles() {
+  const files = []
+
+  async function walk(current) {
+    const entries = await readdir(current, { withFileTypes: true })
+    for (const entry of entries) {
+      if (ignoredDirs.has(entry.name)) continue
+      const absolutePath = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        await walk(absolutePath)
+        continue
+      }
+      const ext = path.extname(entry.name)
+      if (!validExtensions.has(ext)) continue
+      files.push(absolutePath)
+    }
+  }
+
+  for (const dir of includeDirs) {
+    const absoluteDir = path.join(root, dir)
+    if (existsSync(absoluteDir)) {
+      await walk(absoluteDir)
+    }
+  }
+
+  return files
+}
+
+function isAllowed(match) {
+  const lower = match.toLowerCase()
+  if (lower === "#000" || lower === "#fff") return true
+  return false
+}
+
+async function run() {
+  const files = await collectFiles()
+  const violations = []
+
+  for (const file of files) {
+    const contents = await readFile(file, "utf8")
+    const relative = path.relative(root, file)
+    if (ignoredPathFragments.some((fragment) => relative.includes(fragment))) {
+      continue
+    }
+
+    const hexMatches = contents.match(hexPattern) ?? []
+    for (const match of hexMatches) {
+      if (isAllowed(match)) continue
+      violations.push({ file: relative, type: "hex", value: match })
+    }
+
+    const arbitraryMatches = contents.match(arbitraryValuePattern) ?? []
+    for (const match of arbitraryMatches) {
+      violations.push({ file: relative, type: "arbitrary", value: match })
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error("Design lint violations detected:\n")
+    for (const violation of violations) {
+      console.error(`- [${violation.type}] ${violation.value} → ${violation.file}`)
+    }
+    console.error("\nResolve the violations above or update the guard allow list.")
+    process.exitCode = 1
+    return
+  }
+
+  console.log("Design lint guard passed — no raw hex or arbitrary Tailwind values detected.")
+}
+
+run().catch((error) => {
+  console.error("design lint guard failed", error)
+  process.exitCode = 1
+})

--- a/scripts/setup-tailwindcss-eslint-shim.js
+++ b/scripts/setup-tailwindcss-eslint-shim.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+ 
+const { writeFile, access, readFile } = require("node:fs/promises")
+const path = require("node:path")
+const targetPath = path.join(process.cwd(), "node_modules", "tailwindcss", "resolveConfig.js")
+const packageJsonPath = path.join(process.cwd(), "node_modules", "tailwindcss", "package.json")
+
+async function ensureShim() {
+  let shimCreated = false
+  try {
+    await access(targetPath)
+  } catch (error) {
+    if (error && error.code !== "ENOENT") {
+      throw error
+    }
+    const contents = `module.exports = function resolveConfig(config) {\n  return config || {};\n};\n`
+    await writeFile(targetPath, contents, "utf8")
+    console.log("[tailwindcss] Added resolveConfig shim for eslint-plugin-tailwindcss")
+    shimCreated = true
+  }
+
+  const pkgRaw = await readFile(packageJsonPath, "utf8")
+  const pkg = JSON.parse(pkgRaw)
+  pkg.exports = pkg.exports || {}
+  if (!pkg.exports["./resolveConfig"]) {
+    pkg.exports["./resolveConfig"] = "./resolveConfig.js"
+  }
+  if (!pkg.exports["./resolveConfig.js"]) {
+    pkg.exports["./resolveConfig.js"] = "./resolveConfig.js"
+  }
+  await writeFile(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8")
+  if (!shimCreated) {
+    console.log("[tailwindcss] ensure resolveConfig exports for eslint-plugin-tailwindcss")
+  }
+}
+
+ensureShim().catch((error) => {
+  console.error("Failed to create tailwindcss resolveConfig shim", error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary
- add a codemod toolkit plus node guards to enforce DS usage and expose them through new npm scripts
- register Container/Section/Badge primitives via the design-system registry and extend Badge variants & Card typing for downstream consumers
- migrate marketing, pricing, and diagnostic surfaces to DS patterns with accompanying stories and a migration report
- align eslint-plugin-tailwindcss with the Tailwind v4-compatible prerelease and refresh the migration report TODOs
- ensure Docker dependency installs copy the Tailwind eslint shim so the prepare hook succeeds

## Changelog
- add `scripts/codemods/ds/*`, `scripts/guards/design-lints.js`, and `scripts/setup-tailwindcss-eslint-shim.js`; wire npm scripts, lint-staged, and git hooks
- introduce `lib/design-system/component-registry.ts` and update exports (`lib/design-system/index.ts`, `components/ui/card.tsx`, `components/ui/index.ts`)
- update `Container`, `Section`, Badge primitives and migrate `TrustedBySection`, `PricingCard`, `enhanced-social-proof`, and `ScoreChart`
- add Storybook coverage for Container, Badge, and PricingCard patterns plus `docs/ds-migration-report.md`
- bump `eslint-plugin-tailwindcss` to the Tailwind v4-compatible prerelease and refresh the migration report TODOs
- tighten eslint overrides for scripts and ensure design lint guard is referenced by npm scripts
- copy `scripts/setup-tailwindcss-eslint-shim.js` into the Docker deps stage so npm prepare works during builds

## Checklist
- [x] No local designTokens in targeted modules
- [x] No raw hex/rgb or gradients inline
- [x] DS `<Container>`/`<Section>` adopted
- [x] Buttons use DS variants; focus-visible ring present
- [x] Badges use DS `<Badge tone>` variants
- [x] Stories added/updated; Storybook build green
- [x] Lint/CI guardrails added
- [x] `docs/ds-migration-report.md` included

------
https://chatgpt.com/codex/tasks/task_e_68d0865998788325b0cd72fe377cdc78