### PR TITLE
A/B Test: Diagnostic Results Verdict & Signup Module Copy

### DIFF
--- a/__tests__/signup.page.test.tsx
+++ b/__tests__/signup.page.test.tsx
@@ -84,3 +84,142 @@ test('handles API errors correctly', async () => {
     error_message: 'Email already registered',
   });
 });
+
+describe('Signup Attribution Tracking', () => {
+  beforeEach(() => {
+    // Mock localStorage
+    const localStorageMock = {
+      getItem: jest.fn(),
+      setItem: jest.fn(),
+      removeItem: jest.fn(),
+      clear: jest.fn(),
+    };
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      writable: true,
+    });
+  });
+
+  test('includes attribution properties when marker exists from diagnostic summary', async () => {
+    const localStorageMock = window.localStorage as unknown as {
+      getItem: jest.Mock;
+      setItem: jest.Mock;
+      removeItem: jest.Mock;
+    };
+
+    // Set attribution marker (as if user clicked signup CTA from diagnostic summary)
+    localStorageMock.getItem.mockImplementation((key: string) => {
+      if (key === 'signup_attribution_source') return 'diagnostic_summary';
+      if (key === 'signup_attribution_variant') return 'risk_qualifier';
+      if (key === 'signup_attribution_sessionId') return 'test-session-123';
+      if (key === 'signup_attribution_timestamp') return (Date.now() - 5000).toString(); // 5 seconds ago
+      return null;
+    });
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: 'ok', guestUpgraded: false, sessionsTransferred: 0 }),
+    });
+
+    render(<SignupPage />);
+    await userEvent.type(screen.getByPlaceholderText(/email address/i), 'test@example.com');
+    await userEvent.type(screen.getByPlaceholderText(/password/i), 'password123');
+    await userEvent.click(screen.getByRole('button', { name: /sign up/i }));
+
+    await waitFor(() => {
+      // Verify signup_attempt includes attribution
+      expect(captureMock).toHaveBeenCalledWith(
+        'signup_attempt',
+        expect.objectContaining({
+          source: 'diagnostic_summary',
+          signup_attribution_source: 'diagnostic_summary',
+          signup_attribution_variant: 'risk_qualifier',
+          signup_module_copy_variant: 'risk_qualifier',
+          signup_attribution_sessionId: 'test-session-123',
+          ms_since_summary_view: expect.any(Number),
+        })
+      );
+
+      // Verify signup_success includes attribution
+      expect(captureMock).toHaveBeenCalledWith(
+        'signup_success',
+        expect.objectContaining({
+          guestUpgraded: false,
+          sessionsTransferred: 0,
+          signup_attribution_source: 'diagnostic_summary',
+          signup_attribution_variant: 'risk_qualifier',
+          signup_module_copy_variant: 'risk_qualifier',
+          signup_attribution_sessionId: 'test-session-123',
+          ms_since_summary_view: expect.any(Number),
+        })
+      );
+
+      // Verify attribution marker was cleared after success
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith('signup_attribution_source');
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith('signup_attribution_variant');
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith('signup_attribution_sessionId');
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith('signup_attribution_timestamp');
+    });
+  });
+
+  test('uses default source when no attribution marker exists', async () => {
+    const localStorageMock = window.localStorage as unknown as {
+      getItem: jest.Mock;
+    };
+
+    localStorageMock.getItem.mockReturnValue(null);
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: 'ok', guestUpgraded: false, sessionsTransferred: 0 }),
+    });
+
+    render(<SignupPage />);
+    await userEvent.type(screen.getByPlaceholderText(/email address/i), 'test@example.com');
+    await userEvent.type(screen.getByPlaceholderText(/password/i), 'password123');
+    await userEvent.click(screen.getByRole('button', { name: /sign up/i }));
+
+    await waitFor(() => {
+      // Verify signup_attempt uses default source
+      expect(captureMock).toHaveBeenCalledWith(
+        'signup_attempt',
+        expect.objectContaining({
+          source: 'signup_page',
+        })
+      );
+
+      // Should not include attribution properties
+      const signupAttemptCall = captureMock.mock.calls.find(
+        (call: unknown[]) => Array.isArray(call) && call[0] === 'signup_attempt'
+      );
+      expect(signupAttemptCall[1]).not.toHaveProperty('signup_attribution_source');
+    });
+  });
+
+  test('handles localStorage errors gracefully', async () => {
+    const localStorageMock = window.localStorage as unknown as {
+      getItem: jest.Mock;
+    };
+
+    // Simulate localStorage error
+    localStorageMock.getItem.mockImplementation(() => {
+      throw new Error('localStorage unavailable');
+    });
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: 'ok', guestUpgraded: false, sessionsTransferred: 0 }),
+    });
+
+    // Should not throw and should use default source
+    render(<SignupPage />);
+    await userEvent.type(screen.getByPlaceholderText(/email address/i), 'test@example.com');
+    await userEvent.type(screen.getByPlaceholderText(/password/i), 'password123');
+    await userEvent.click(screen.getByRole('button', { name: /sign up/i }));
+
+    await waitFor(() => {
+      expect(captureMock).toHaveBeenCalledWith('signup_attempt', expect.any(Object));
+      expect(captureMock).toHaveBeenCalledWith('signup_success', expect.any(Object));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
• Implemented A/B test for diagnostic results page verdict copy ("Ready" vs "Ready — with risk")
• Added signup module copy variant ("Unlock full breakdown" vs "Save your results (recommended)")
• Fixed Next.js 15 build error preventing deployment
• Both tests use single feature flag for simplified analysis

## Technical Details
• **Feature Flag**: \`diagnostic_results_verdict_copy\` (multivariate: control 50%, risk_qualifier 50%)
• **Verdict Copy Logic**: Treatment variant shows weakest domains with risk qualifier messaging
• **Signup Module Copy**: Treatment uses loss aversion framing ("Save your results") vs control ("Unlock full breakdown")
• **Attribution Tracking**: localStorage markers persist across navigation to link signup completion to variant
• **Next.js Fix**: Added \`export const dynamic = 'force-dynamic'\` to signup page to resolve prerendering error

**Architecture Decisions:**
- Reused single feature flag for both tests to simplify PostHog experiment analysis
- Client-side attribution via localStorage (no server-side session needed)
- Graceful degradation when localStorage unavailable (private browsing, etc.)

## Test Coverage
• **Integration Tests**: Added comprehensive coverage for both verdict and signup module variants
  - Control and treatment copy rendering verified
  - Analytics event properties validated for both variants
  - Attribution marker lifecycle tested (set → read → clear)
• **Unit Tests**: Signup page attribution tracking logic covered
  - Handles missing markers gracefully
  - Includes attribution in analytics events
  - Clears markers after successful signup

## Security Review
• No security implications - client-side feature flagging and analytics only
• localStorage usage is safe (no sensitive data stored)
• Attribution markers are cleared after use

## Performance Impact
• Minimal - feature flag check is synchronous PostHog call
• localStorage operations are negligible
• No additional API calls or database queries

## PostHog Setup Required
Before merging, configure PostHog:
1. Update feature flag \`diagnostic_results_verdict_copy\` to multivariate (control 50%, risk_qualifier 50%)
2. Create experiment linked to flag with conversion metric: \`signup_success\` (filtered by \`signup_attribution_source=diagnostic_summary\`)
3. Or run: \`scripts/setup-posthog-ab-test.sh\` (requires \`POSTHOG_PERSONAL_API_KEY\`)

See \`docs/posthog-ab-test-setup.md\` for detailed setup instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced A/B test variants for signup module messaging, displaying variant-specific copy and call-to-action buttons
  * Enhanced signup attribution tracking to capture source, variant, and session information for improved conversion insights

* **Tests**
  * Added comprehensive test coverage for signup attribution tracking and A/B variant behavior verification

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->